### PR TITLE
feat: add InfluxDB 2.x support and rename InfluxDB 3 to influxdb3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   
   ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)
   ![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
-  ![Databases](https://img.shields.io/badge/Databases-18-success)
+  ![Databases](https://img.shields.io/badge/Databases-19-success)
   ![CLI](https://img.shields.io/badge/CLI-Tool-blue)
   
   ![Security](https://img.shields.io/badge/Security-0%20vulnerabilities-brightgreen)
@@ -78,8 +78,9 @@ All databases are **100% open-source** with permissive licenses:
 </details>
 
 <details>
-<summary><strong>Time Series Databases (5)</strong></summary>
+<summary><strong>Time Series Databases (6)</strong></summary>
 
+- **InfluxDB 2.x** (MIT/Apache 2.0) - Modern time series with Python integration
 - **InfluxDB 3 Core** (MIT/Apache 2.0) - Modern time series with Python integration
 - **TimescaleDB** (Timescale License) - PostgreSQL-based time series database
 - **QuestDB** (Apache 2.0) - High-performance time series with SQL support
@@ -111,7 +112,7 @@ All databases are **100% open-source** with permissive licenses:
 - **LevelDB** (BSD) - High-performance key-value storage library
 </details>
 
-**Total: 18 databases across 8 categories**
+**Total: 19 databases across 8 categories**
 
 ## 🛠️ Installation
 
@@ -258,7 +259,7 @@ hayai list
 hayai init -n vectors -e qdrant -y
 
 # Time series for metrics
-hayai init -n metrics -e influxdb -y
+hayai init -n metrics -e influxdb3 -y
 
 # Traditional data storage
 hayai init -n data -e postgresql -y
@@ -306,7 +307,7 @@ hayai init -n graph -e arangodb -p 8529 -y
 
 ### 📊 Comprehensive Database Support
 - **SQL Databases** - PostgreSQL, MariaDB, SQLite, DuckDB
-- **Time Series** - InfluxDB, TimescaleDB, QuestDB, VictoriaMetrics, HoraeDB
+- **Time Series** - InfluxDB 2.x, InfluxDB 3 Core, TimescaleDB, QuestDB, VictoriaMetrics, HoraeDB
 - **Vector Search** - Qdrant, Weaviate, Milvus
 - **Search Engines** - Meilisearch, Typesense
 - **Specialized** - Redis, Cassandra, ArangoDB, LevelDB

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "meilisearch",
     "sqlite",
     "duckdb",
-    "influxdb",
+    "influxdb2",
+    "influxdb3",
     "timescaledb",
     "questdb"
   ],

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,7 +56,7 @@ ${chalk.bold('SUPPORTED DATABASES')}
   ${chalk.green('SQL:')}           postgresql, mariadb, sqlite, duckdb
   ${chalk.green('Key-Value:')}     redis
   ${chalk.green('Wide Column:')}   cassandra
-  ${chalk.green('Time Series:')}   influxdb, timescaledb, questdb, victoriametrics, horaedb
+  ${chalk.green('Time Series:')}   influxdb2, influxdb3, timescaledb, questdb, victoriametrics, horaedb
   ${chalk.green('Vector:')}        qdrant, weaviate, milvus
   ${chalk.green('Graph:')}         arangodb
   ${chalk.green('Search:')}        meilisearch, typesense

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -260,7 +260,10 @@ export class DockerManager {
         return `leveldb:///${dbName}`;
       
       // Time Series Databases
-      case 'influxdb':
+      case 'influxdb3':
+        return `http://localhost:${port}`;
+      
+      case 'influxdb2':
         return `http://localhost:${port}`;
       
       case 'timescaledb':
@@ -296,7 +299,8 @@ export class DockerManager {
       duckdb: 'alpine:latest',
       leveldb: 'alpine:latest',
       // Time Series Databases
-      influxdb: 'influxdb:latest',
+      influxdb3: 'influxdb:latest',
+      influxdb2: 'influxdb:latest',
       timescaledb: 'timescale/timescaledb:latest-pg16',
       questdb: 'questdb/questdb:latest',
       victoriametrics: 'victoriametrics/victoria-metrics:latest',
@@ -322,7 +326,8 @@ export class DockerManager {
       duckdb: 0, // No port for embedded
       leveldb: 0, // No port for embedded
       // Time Series Databases
-      influxdb: 8086,
+      influxdb3: 8086,
+      influxdb2: 8086,
       timescaledb: 5432,
       questdb: 9000,
       victoriametrics: 8428,
@@ -348,7 +353,8 @@ export class DockerManager {
       duckdb: '/data',
       leveldb: '/data',
       // Time Series Databases
-      influxdb: '/var/lib/influxdb3',
+      influxdb3: '/var/lib/influxdb3',
+      influxdb2: '/var/lib/influxdb2',
       timescaledb: '/var/lib/postgresql/data',
       questdb: '/var/lib/questdb',
       victoriametrics: '/victoria-metrics-data',
@@ -421,7 +427,13 @@ export class DockerManager {
         retries: 5,
       },
       // Time Series Databases
-      influxdb: {
+      influxdb3: {
+        test: 'curl -f http://localhost:8086/health || exit 1',
+        interval: '10s',
+        timeout: '5s',
+        retries: 5,
+      },
+      influxdb2: {
         test: 'curl -f http://localhost:8086/health || exit 1',
         interval: '10s',
         timeout: '5s',

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -311,10 +311,10 @@ export class DatabaseTemplates {
     });
 
     // ✅ Time Series Databases (100% Open-Source)
-    this.addTemplate('influxdb', {
+    this.addTemplate('influxdb3', {
       name: 'InfluxDB 3 Core',
       engine: {
-        name: 'influxdb',
+        name: 'influxdb3',
         type: 'timeseries',
         version: '3.0',
         image: 'influxdb:latest',
@@ -340,6 +340,41 @@ export class DatabaseTemplates {
       client_sdk: {
         enabled: true,
         languages: ['typescript', 'python', 'javascript', 'go'],
+      },
+    });
+
+    this.addTemplate('influxdb2', {
+      name: 'InfluxDB 2.x',
+      engine: {
+        name: 'influxdb2',
+        type: 'timeseries',
+        version: '2.7',
+        image: 'influxdb:2.7-alpine',
+        ports: [8086],
+        volumes: ['/var/lib/influxdb2'],
+        environment: {
+          DOCKER_INFLUXDB_INIT_MODE: 'setup',
+          DOCKER_INFLUXDB_INIT_USERNAME: 'admin',
+          DOCKER_INFLUXDB_INIT_PASSWORD: 'password123',
+          DOCKER_INFLUXDB_INIT_ORG: 'hayai',
+          DOCKER_INFLUXDB_INIT_BUCKET: 'hayai_bucket',
+          DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: 'hayai-admin-token-12345',
+        },
+        healthcheck: {
+          test: 'curl -f http://localhost:8086/health || exit 1',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+      admin_dashboard: {
+        enabled: true,
+        port: 8086,
+        image: 'influxdb:2.7-alpine',
+      },
+      client_sdk: {
+        enabled: true,
+        languages: ['typescript', 'python', 'javascript', 'go', 'java'],
       },
     });
 
@@ -571,10 +606,15 @@ export class DatabaseTemplates {
         fullyOpenSource: true,
         notes: 'Low-level, used internally by many tools'
       },
-      influxdb: {
+      influxdb3: {
         license: 'MIT/Apache 2.0',
         fullyOpenSource: true,
         notes: 'InfluxDB 3 Core - Optimized for recent data (72h), with integrated Python'
+      },
+      influxdb2: {
+        license: 'MIT',
+        fullyOpenSource: true,
+        notes: 'InfluxDB 2.x - Mature, stable, full-featured time series platform'
       },
       timescaledb: {
         license: 'Timescale License (TSL)',

--- a/src/tests/unit/templates.test.ts
+++ b/src/tests/unit/templates.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from '@jest/globals';
 import { DatabaseTemplates } from '../../core/templates.js';
 
 describe('DatabaseTemplates - Basic Validation', () => {
-  it('should return all 18 configured databases', () => {
+  it('should return all 19 configured databases', () => {
     const templates = DatabaseTemplates.getAllTemplates();
-    expect(templates.size).toBe(18);
+    expect(templates.size).toBe(19);
   });
 
   it('should have valid structure for all templates', () => {
@@ -20,10 +20,11 @@ describe('DatabaseTemplates - Basic Validation', () => {
     });
   });
 
-  it('should include all 5 time series databases', () => {
+  it('should include all 6 time series databases', () => {
     const timeseriesEngines = DatabaseTemplates.getEnginesByType('timeseries');
-    expect(timeseriesEngines).toHaveLength(5);
-    expect(timeseriesEngines).toContain('influxdb');
+    expect(timeseriesEngines).toHaveLength(6);
+    expect(timeseriesEngines).toContain('influxdb2');
+    expect(timeseriesEngines).toContain('influxdb3');
     expect(timeseriesEngines).toContain('timescaledb');
   });
 }); 


### PR DESCRIPTION
- Add influxdb2 template with InfluxDB 2.7-alpine configuration
- Rename influxdb template to influxdb3 for better version clarity
- Update Docker configurations for both InfluxDB versions
- Add proper volume mapping (/var/lib/influxdb2 vs /var/lib/influxdb3)
- Update CLI help text to show influxdb2 and influxdb3
- Update README documentation and examples
- Update tests to reflect 19 total databases (6 time series)
- Update package.json keywords with specific versions