### PR TITLE
fix: resolve runtime-breaking bugs from code audit

### DIFF
--- a/src/cli/commands/clone.ts
+++ b/src/cli/commands/clone.ts
@@ -4,6 +4,7 @@ import inquirer from 'inquirer';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
 import { getTemplate } from '../../core/templates.js';
+import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { CLIOptions } from '../../core/types.js';
 import { spawn } from 'child_process';
 
@@ -122,10 +123,10 @@ async function cloneData(source: any, targetName: string): Promise<void> {
   
   switch (source.engine) {
     case 'postgresql':
-      await clonePostgreSQL(sourceContainer, targetContainer);
+      await clonePostgreSQL(sourceContainer, targetContainer, source.environment);
       break;
     case 'mariadb':
-      await cloneMariaDB(sourceContainer, targetContainer);
+      await cloneMariaDB(sourceContainer, targetContainer, source.environment);
       break;
     case 'redis':
       await cloneRedis(sourceContainer, targetContainer);
@@ -140,16 +141,24 @@ async function cloneData(source: any, targetName: string): Promise<void> {
   }
 }
 
-async function clonePostgreSQL(sourceContainer: string, targetContainer: string): Promise<void> {
+async function clonePostgreSQL(
+  sourceContainer: string,
+  targetContainer: string,
+  environment: Record<string, string> = {}
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    // The target is freshly created with the same environment, so the
+    // same-named empty database already exists there — a plain dump/restore
+    // into it is enough.
+    const { user, database } = getPostgresExecCredentials(environment);
     const dumpProcess = spawn('docker', [
       'exec', sourceContainer,
-      'pg_dump', '-U', 'postgres', '--clean', '--create'
+      'pg_dump', '-U', user, '-d', database
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
-    
+
     const restoreProcess = spawn('docker', [
       'exec', '-i', targetContainer,
-      'psql', '-U', 'postgres'
+      'psql', '-U', user, '-d', database
     ], { stdio: ['pipe', 'inherit', 'pipe'] });
     
     dumpProcess.stdout.pipe(restoreProcess.stdin);
@@ -163,15 +172,23 @@ async function clonePostgreSQL(sourceContainer: string, targetContainer: string)
   });
 }
 
-async function cloneMariaDB(sourceContainer: string, targetContainer: string): Promise<void> {
+async function cloneMariaDB(
+  sourceContainer: string,
+  targetContainer: string,
+  environment: Record<string, string> = {}
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    const rootPassword = getMariaDBRootPassword(environment);
+    const dumpTarget = environment.MYSQL_DATABASE
+      ? ['--databases', environment.MYSQL_DATABASE]
+      : ['--all-databases'];
     const dumpProcess = spawn('docker', [
-      'exec', sourceContainer,
-      'mysqldump', '-u', 'root', '--all-databases'
+      'exec', '-e', `MYSQL_PWD=${rootPassword}`, sourceContainer,
+      'mysqldump', '-u', 'root', ...dumpTarget
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
-    
+
     const restoreProcess = spawn('docker', [
-      'exec', '-i', targetContainer,
+      'exec', '-i', '-e', `MYSQL_PWD=${rootPassword}`, targetContainer,
       'mysql', '-u', 'root'
     ], { stdio: ['pipe', 'inherit', 'pipe'] });
     

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
+import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { CLIOptions } from '../../core/types.js';
 import { spawn } from 'child_process';
 
@@ -60,10 +61,10 @@ async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise
     // Same engine - use engine-specific merge
     switch (sourceInstance.engine) {
       case 'postgresql':
-        await mergePostgreSQL(sourceContainer, targetContainer);
+        await mergePostgreSQL(sourceContainer, targetContainer, sourceInstance.environment, targetInstance.environment);
         break;
       case 'mariadb':
-        await mergeMariaDB(sourceContainer, targetContainer);
+        await mergeMariaDB(sourceContainer, targetContainer, sourceInstance.environment, targetInstance.environment);
         break;
       case 'redis':
         await mergeRedis(sourceContainer, targetContainer);
@@ -76,19 +77,26 @@ async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise
   console.log(chalk.green(`✅ Successfully merged ${sourceInstance.name} ↔ ${targetInstance.name}`));
 }
 
-async function mergePostgreSQL(sourceContainer: string, targetContainer: string): Promise<void> {
+async function mergePostgreSQL(
+  sourceContainer: string,
+  targetContainer: string,
+  sourceEnv: Record<string, string> = {},
+  targetEnv: Record<string, string> = {}
+): Promise<void> {
   console.log(chalk.yellow('🔄 Merging PostgreSQL databases...'));
-  
+
   return new Promise((resolve, reject) => {
     // Simplified merge - in real implementation would be more sophisticated
+    const source = getPostgresExecCredentials(sourceEnv);
+    const target = getPostgresExecCredentials(targetEnv);
     const dumpProcess = spawn('docker', [
       'exec', sourceContainer,
-      'pg_dump', '-U', 'postgres', '--data-only'
+      'pg_dump', '-U', source.user, '-d', source.database, '--data-only'
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
-    
+
     const restoreProcess = spawn('docker', [
       'exec', '-i', targetContainer,
-      'psql', '-U', 'postgres', '-v', 'ON_ERROR_STOP=0'
+      'psql', '-U', target.user, '-d', target.database, '-v', 'ON_ERROR_STOP=0'
     ], { stdio: ['pipe', 'inherit', 'pipe'] });
     
     dumpProcess.stdout.pipe(restoreProcess.stdin);
@@ -103,18 +111,30 @@ async function mergePostgreSQL(sourceContainer: string, targetContainer: string)
   });
 }
 
-async function mergeMariaDB(sourceContainer: string, targetContainer: string): Promise<void> {
+async function mergeMariaDB(
+  sourceContainer: string,
+  targetContainer: string,
+  sourceEnv: Record<string, string> = {},
+  targetEnv: Record<string, string> = {}
+): Promise<void> {
   console.log(chalk.yellow('🔄 Merging MariaDB databases...'));
-  
+
   return new Promise((resolve, reject) => {
+    const sourceDb = sourceEnv.MYSQL_DATABASE;
+    const targetDb = targetEnv.MYSQL_DATABASE;
+    if (!sourceDb || !targetDb) {
+      reject(new Error('MariaDB merge requires MYSQL_DATABASE to be set on both instances'));
+      return;
+    }
+
     const dumpProcess = spawn('docker', [
-      'exec', sourceContainer,
-      'mysqldump', '-u', 'root', '--no-create-info', '--complete-insert'
+      'exec', '-e', `MYSQL_PWD=${getMariaDBRootPassword(sourceEnv)}`, sourceContainer,
+      'mysqldump', '-u', 'root', '--no-create-info', '--complete-insert', sourceDb
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
-    
+
     const restoreProcess = spawn('docker', [
-      'exec', '-i', targetContainer,
-      'mysql', '-u', 'root'
+      'exec', '-i', '-e', `MYSQL_PWD=${getMariaDBRootPassword(targetEnv)}`, targetContainer,
+      'mysql', '-u', 'root', '--force', targetDb
     ], { stdio: ['pipe', 'inherit', 'pipe'] });
     
     dumpProcess.stdout.pipe(restoreProcess.stdin);
@@ -277,13 +297,13 @@ async function handleMerge(options: MergeOptions): Promise<void> {
   // Preview mode
   if (options.preview || (!options.execute && !options.force)) {
     await previewMerge(sourceInstance, targetInstance);
-    
+
     if (!options.execute) {
       console.log(chalk.cyan('\n💡 Use --execute to perform the merge operation'));
       return;
     }
   }
-  
+
   // Final confirmation for destructive operation
   if (!options.force && options.execute) {
     const { proceed } = await inquirer.prompt([

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -294,18 +294,16 @@ async function handleMerge(options: MergeOptions): Promise<void> {
     process.exit(1);
   }
   
-  // Preview mode
-  if (options.preview || (!options.execute && !options.force)) {
+  // Preview mode: explicit --preview, or any invocation without --execute.
+  // --force never substitutes for --execute; it only skips the confirmation.
+  if (options.preview || !options.execute) {
     await previewMerge(sourceInstance, targetInstance);
-
-    if (!options.execute) {
-      console.log(chalk.cyan('\n💡 Use --execute to perform the merge operation'));
-      return;
-    }
+    console.log(chalk.cyan('\n💡 Use --execute to perform the merge operation'));
+    return;
   }
 
   // Final confirmation for destructive operation
-  if (!options.force && options.execute) {
+  if (!options.force) {
     const { proceed } = await inquirer.prompt([
       {
         type: 'confirm',

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -4,6 +4,7 @@ import inquirer from 'inquirer';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
 import { getTemplate } from '../../core/templates.js';
+import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { CLIOptions } from '../../core/types.js';
 import { spawn } from 'child_process';
 import fs from 'fs-extra';
@@ -262,9 +263,9 @@ async function executeMigration(sourceInstance: any, targetName: string, targetE
   }
 
   logMigrationStep('Creating target database container...');
-  
+
   // Create target database
-  await dockerManager.createDatabase(
+  const targetInstance = await dockerManager.createDatabase(
     targetName,
     targetTemplate,
     {
@@ -275,12 +276,12 @@ async function executeMigration(sourceInstance: any, targetName: string, targetE
   );
 
   logMigrationStep('Starting target database...', 'Waiting for initialization');
-  
+
   // Start target database
   await dockerManager.startDatabase(targetName);
-  
+
   // Wait for database to be ready with progress
-  await waitForDatabaseReady(targetName, targetEngine);
+  await waitForDatabaseReady(targetName, targetEngine, targetInstance.environment);
 
   logMigrationStep('Executing migration strategy...', getMigrationStrategy(sourceInstance.engine, targetEngine));
   
@@ -291,40 +292,51 @@ async function executeMigration(sourceInstance: any, targetName: string, targetE
   logMigrationStep('Migration completed successfully!', `${sourceInstance.name} → ${targetName}`);
 }
 
-async function waitForDatabaseReady(containerName: string, engine: string): Promise<void> {
+async function waitForDatabaseReady(
+  containerName: string,
+  engine: string,
+  environment: Record<string, string> = {}
+): Promise<void> {
   const maxAttempts = 30;
   const interval = 2000;
-  
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      logMigrationStep(`Health check (${attempt}/${maxAttempts})...`, `Checking ${engine} readiness`);
-      
-      const isReady = await checkDatabaseHealth(containerName, engine);
-      if (isReady) {
-        logMigrationStep('Database is ready!', 'Health check passed');
-        return;
-      }
-      
+    logMigrationStep(`Health check (${attempt}/${maxAttempts})...`, `Checking ${engine} readiness`);
+
+    const isReady = await checkDatabaseHealth(containerName, engine, environment).catch(() => false);
+    if (isReady) {
+      logMigrationStep('Database is ready!', 'Health check passed');
+      return;
+    }
+
+    if (attempt < maxAttempts) {
       await new Promise(resolve => setTimeout(resolve, interval));
-    } catch (error) {
-      if (attempt === maxAttempts) {
-        throw new Error(`Database failed to become ready after ${maxAttempts} attempts`);
-      }
     }
   }
+
+  throw new Error(`Database '${containerName}' failed to become ready after ${maxAttempts} attempts`);
 }
 
-async function checkDatabaseHealth(containerName: string, engine: string): Promise<boolean> {
+async function checkDatabaseHealth(
+  containerName: string,
+  engine: string,
+  environment: Record<string, string> = {}
+): Promise<boolean> {
   return new Promise((resolve) => {
     let healthCommand: string[] = [];
-    
+
     switch (engine) {
       case 'postgresql':
-      case 'timescaledb':
-        healthCommand = ['docker', 'exec', `${containerName}-db`, 'pg_isready', '-U', 'postgres'];
+      case 'timescaledb': {
+        const { user, database } = getPostgresExecCredentials(environment);
+        healthCommand = ['docker', 'exec', `${containerName}-db`, 'pg_isready', '-U', user, '-d', database];
         break;
+      }
       case 'mariadb':
-        healthCommand = ['docker', 'exec', `${containerName}-db`, 'mysqladmin', 'ping', '-u', 'root'];
+        healthCommand = [
+          'docker', 'exec', '-e', `MYSQL_PWD=${getMariaDBRootPassword(environment)}`,
+          `${containerName}-db`, 'mysqladmin', 'ping', '-u', 'root'
+        ];
         break;
       case 'redis':
         healthCommand = ['docker', 'exec', `${containerName}-db`, 'redis-cli', 'ping'];
@@ -369,7 +381,7 @@ async function executeMigrationStrategy(source: any, targetName: string, targetE
       await migratePrometheusToInflux();
       break;
     case 'sql_to_line_protocol':
-      await migrateSQLToLineProtocol(sourceContainer, targetContainer, source.engine);
+      await migrateSQLToLineProtocol(sourceContainer, targetContainer, source.engine, source.environment);
       break;
     case 'postgres_to_timescale':
       await migratePostgresToTimescale();
@@ -456,7 +468,12 @@ async function migrateInfluxLineProtocol(sourceContainer: string, targetContaine
   });
 }
 
-async function migrateSQLToLineProtocol(sourceContainer: string, targetContainer: string, sourceEngine: string): Promise<void> {
+async function migrateSQLToLineProtocol(
+  sourceContainer: string,
+  targetContainer: string,
+  sourceEngine: string,
+  sourceEnv: Record<string, string> = {}
+): Promise<void> {
   return new Promise((resolve, reject) => {
     logMigrationStep('Converting SQL data to Line Protocol format...');
     
@@ -486,9 +503,10 @@ async function migrateSQLToLineProtocol(sourceContainer: string, targetContainer
     logMigrationStep('Executing SQL conversion query...', `Engine: ${sourceEngine}`);
     
     // Export from SQL database
+    const { user, database } = getPostgresExecCredentials(sourceEnv);
     const exportProcess = spawn('docker', [
       'exec', sourceContainer,
-      'psql', '-U', 'postgres', '-t', '-c', conversionQuery
+      'psql', '-U', user, '-d', database, '-t', '-c', conversionQuery
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
     
     let convertedRows = 0;

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -46,11 +46,14 @@ export const removeCommand = new Command('remove')
       }
 
       // Remove the database
-      await dockerManager.removeDatabase(name);
+      await dockerManager.removeDatabase(name, { keepData: options.keepData });
 
       spinner.succeed(`Database '${name}' removed successfully`);
 
       console.log(chalk.green('\n✅ Database removed!'));
+      if (options.keepData) {
+        console.log(chalk.yellow(`💡 Data volume kept at: ${instance.volume}`));
+      }
       console.log(chalk.yellow('💡 Run `hayai list` to see remaining databases'));
 
     } catch (error) {

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -3,9 +3,11 @@ import chalk from 'chalk';
 import ora from 'ora';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { createWriteStream } from 'fs';
 import { spawn } from 'child_process';
 import { getDockerManager } from '../../core/docker.js';
 import { getTemplate } from '../../core/templates.js';
+import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { SnapshotOptions } from '../../core/types.js';
 
 async function createSnapshotDirectory(dir: string): Promise<void> {
@@ -29,10 +31,10 @@ async function createSnapshot(
   switch (instance.engine) {
     case 'postgresql':
     case 'timescaledb':
-      await createPostgreSQLSnapshot(instance.name, snapshotPath);
+      await createPostgreSQLSnapshot(instance.name, snapshotPath, instance.environment);
       break;
     case 'mariadb':
-      await createMariaDBSnapshot(instance.name, snapshotPath);
+      await createMariaDBSnapshot(instance.name, snapshotPath, instance.environment);
       break;
     case 'redis':
       await createRedisSnapshot(instance.name, snapshotPath);
@@ -49,14 +51,19 @@ async function createSnapshot(
   }
 }
 
-async function createPostgreSQLSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
+async function createPostgreSQLSnapshot(
+  instanceName: string,
+  snapshotPath: string,
+  environment: Record<string, string> = {}
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    const { user, database } = getPostgresExecCredentials(environment);
     const dumpProcess = spawn('docker', [
       'exec', `${instanceName}-db`,
-      'pg_dump', '-U', 'postgres', '--clean', '--create'
+      'pg_dump', '-U', user, '-d', database, '--clean', '--create'
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
 
-    const writeStream = require('fs').createWriteStream(snapshotPath);
+    const writeStream = createWriteStream(snapshotPath);
     dumpProcess.stdout.pipe(writeStream);
 
     dumpProcess.on('close', (code) => {
@@ -68,14 +75,19 @@ async function createPostgreSQLSnapshot(instanceName: string, snapshotPath: stri
   });
 }
 
-async function createMariaDBSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
+async function createMariaDBSnapshot(
+  instanceName: string,
+  snapshotPath: string,
+  environment: Record<string, string> = {}
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    const rootPassword = getMariaDBRootPassword(environment);
     const dumpProcess = spawn('docker', [
-      'exec', `${instanceName}-db`,
+      'exec', '-e', `MYSQL_PWD=${rootPassword}`, `${instanceName}-db`,
       'mysqldump', '-u', 'root', '--all-databases'
     ], { stdio: ['inherit', 'pipe', 'pipe'] });
 
-    const writeStream = require('fs').createWriteStream(snapshotPath);
+    const writeStream = createWriteStream(snapshotPath);
     dumpProcess.stdout.pipe(writeStream);
 
     dumpProcess.on('close', (code) => {

--- a/src/core/credentials.ts
+++ b/src/core/credentials.ts
@@ -1,0 +1,25 @@
+// Derives the credentials needed by exec'd database tooling (pg_dump, psql,
+// mysqldump, pg_isready, ...) from the environment an instance was created with.
+// Inside the official postgres image, `docker exec` connects over the local
+// socket which uses trust auth, so only user/database are needed. MariaDB
+// clients require the root password, passed via the MYSQL_PWD env var so it
+// never appears in the command line inside the container.
+
+export interface PostgresExecCredentials {
+  user: string;
+  database: string;
+}
+
+export function getPostgresExecCredentials(
+  environment: Record<string, string> = {}
+): PostgresExecCredentials {
+  const user = environment.POSTGRES_USER || 'postgres';
+  return {
+    user,
+    database: environment.POSTGRES_DB || user,
+  };
+}
+
+export function getMariaDBRootPassword(environment: Record<string, string> = {}): string {
+  return environment.MYSQL_ROOT_PASSWORD || '';
+}

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -11,6 +11,7 @@ import { allocatePort, deallocatePort } from './port-manager.js';
 interface DockerVerificationResult {
   isInstalled: boolean;
   isRunning: boolean;
+  composeAvailable?: boolean;
   version?: string;
   error?: string;
 }
@@ -61,16 +62,42 @@ export class DockerManager {
         
         // Check if Docker daemon is running
         const pingChild = spawn('docker', ['info'], { stdio: 'pipe' });
-        
+
         pingChild.on('close', (pingCode) => {
-          resolve({
-            isInstalled: true,
-            isRunning: pingCode === 0,
-            version,
-            error: pingCode !== 0 ? 'Docker daemon not running' : undefined
+          if (pingCode !== 0) {
+            resolve({
+              isInstalled: true,
+              isRunning: false,
+              version,
+              error: 'Docker daemon not running'
+            });
+            return;
+          }
+
+          // Daemon is up — verify the Compose V2 plugin is available
+          const composeChild = spawn('docker', ['compose', 'version'], { stdio: 'pipe' });
+
+          composeChild.on('close', (composeCode) => {
+            resolve({
+              isInstalled: true,
+              isRunning: true,
+              composeAvailable: composeCode === 0,
+              version,
+              error: composeCode !== 0 ? 'Docker Compose V2 plugin not found' : undefined
+            });
+          });
+
+          composeChild.on('error', () => {
+            resolve({
+              isInstalled: true,
+              isRunning: true,
+              composeAvailable: false,
+              version,
+              error: 'Docker Compose V2 plugin not found'
+            });
           });
         });
-        
+
         pingChild.on('error', () => {
           resolve({
             isInstalled: true,
@@ -124,6 +151,14 @@ export class DockerManager {
           break;
       }
       
+    } else if (result.isRunning && result.composeAvailable === false) {
+      console.log(chalk.yellow('🐳 Docker is running but the Compose V2 plugin is missing.'));
+      console.log(chalk.gray(`Version: ${result.version}\n`));
+
+      console.log(chalk.bold('📦 Install Docker Compose V2:\n'));
+      console.log(chalk.cyan('  • Docker Desktop: update to a recent version (Compose V2 is included)'));
+      console.log(chalk.cyan('  • Debian/Ubuntu: sudo apt-get install docker-compose-plugin'));
+      console.log(chalk.cyan('  • Other platforms: https://docs.docker.com/compose/install/'));
     } else if (!result.isRunning) {
       console.log(chalk.yellow('🐳 Docker is installed but not running.'));
       console.log(chalk.gray(`Version: ${result.version}\n`));
@@ -157,8 +192,8 @@ export class DockerManager {
     }
     
     const result = await this.checkDockerInstallation();
-    
-    if (!result.isInstalled || !result.isRunning) {
+
+    if (!result.isInstalled || !result.isRunning || !result.composeAvailable) {
       this.showDockerInstallationInstructions(result);
       process.exit(1);
     }
@@ -327,7 +362,7 @@ export class DockerManager {
     const composeFilePath = await getComposeFilePath();
     
     return new Promise((resolve, reject) => {
-      const child = spawn('docker-compose', ['-f', composeFilePath, ...args], {
+      const child = spawn('docker', ['compose', '-f', composeFilePath, ...args], {
         stdio: ['inherit', 'pipe', 'pipe']
       });
 

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -276,7 +276,7 @@ export class DockerManager {
     return instance;
   }
 
-  public async removeDatabase(name: string): Promise<void> {
+  public async removeDatabase(name: string, options: { keepData?: boolean } = {}): Promise<void> {
     const instance = this.instances.get(name);
     if (!instance) {
       throw new Error(`Database instance '${name}' not found`);
@@ -300,8 +300,8 @@ export class DockerManager {
     // Remove from instances
     this.instances.delete(name);
 
-    // Clean up data directory
-    if (await this.pathExists(instance.volume)) {
+    // Clean up data directory unless the caller asked to keep it
+    if (!options.keepData && await this.pathExists(instance.volume)) {
       await rm(instance.volume, { recursive: true });
     }
 
@@ -880,10 +880,13 @@ export const createDatabase = async (
   return await manager.createDatabase(name, template, options);
 };
 
-export const removeDatabase = async (name: string): Promise<void> => {
+export const removeDatabase = async (
+  name: string,
+  options: { keepData?: boolean } = {}
+): Promise<void> => {
   const manager = DockerManager.getInstance();
   await manager.initialize();
-  await manager.removeDatabase(name);
+  await manager.removeDatabase(name, options);
 };
 
 export const startDatabase = async (name: string): Promise<void> => {

--- a/src/core/security.ts
+++ b/src/core/security.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, chmod } from 'fs/promises';
+import { readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
@@ -62,14 +63,14 @@ export class SecurityManager {
     const keyPath = path.join(process.cwd(), '.hayai', '.key');
     
     try {
-      return require('fs').readFileSync(keyPath, 'utf8');
+      return readFileSync(keyPath, 'utf8');
     } catch {
       const key = crypto.randomBytes(32).toString('hex');
       try {
-        require('fs').mkdirSync(path.dirname(keyPath), { recursive: true });
-        require('fs').writeFileSync(keyPath, key);
-        require('fs').chmodSync(keyPath, 0o600); // Only owner can read
-      } catch (error) {
+        mkdirSync(path.dirname(keyPath), { recursive: true });
+        writeFileSync(keyPath, key);
+        chmodSync(keyPath, 0o600); // Only owner can read
+      } catch {
         console.warn(chalk.yellow('⚠️  Could not save encryption key securely'));
       }
       return key;
@@ -142,7 +143,7 @@ export class SecurityManager {
       await writeFile(this.credentialsPath, encryptedCredentials);
       
       // Set restrictive permissions
-      await require('fs').promises.chmod(this.credentialsPath, 0o600);
+      await chmod(this.credentialsPath, 0o600);
       
     } catch (error) {
       throw new Error(`Failed to store credentials securely: ${error}`);


### PR DESCRIPTION
Fixes the six highest-severity findings from a full code audit. Every commit is single-concern; see individual messages for detail.

## What was broken

1. **`require()` in an ESM package** — threw `ReferenceError` at runtime: postgres/mariadb snapshots crashed on first write, the encryption key regenerated on every run (stored credentials permanently undecryptable), and `storeCredentials` always failed.
2. **Wrong credentials in all exec'd DB tooling** — `pg_dump`/`psql`/`pg_isready` ran as the nonexistent `postgres` role and mysqldump as passwordless root, so clone, snapshot, and merge failed for every SQL engine. Tooling now derives credentials from the instance environment (new `src/core/credentials.ts`).
3. **Dependency on removed `docker-compose` V1 binary** — commands now use `docker compose` (V2) and setup verification checks the plugin is present.
4. **`--keep-data` deleted data anyway** — the flag now actually reaches `removeDatabase`.
5. **`merge --force` bypassed `--execute`** — `--force` alone ran the irreversible merge; it now only skips the confirmation prompt.
6. **`waitForDatabaseReady` never failed** — after 30 failed health checks it returned as if ready; it now throws.

Also fixed in passing: mariadb merge invoked `mysqldump` with no database argument (guaranteed usage error).

## Verification

- `npm run build` (tsc) — clean
- `npm test` — 7/7 passing
- `npm run lint` — clean
- `node dist/cli/index.js --version/--help` — OK

Live multi-container behavior (clone/merge/migrate against running Docker) still needs a manual smoke test before release.