### PR TITLE
fix: stop simulating features — every command now does what it claims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^12.1.0",
-        "fs-extra": "^11.3.0",
         "inquirer": "^9.2.12",
         "ora": "^8.2.0",
         "yaml": "^2.8.0"
@@ -20,7 +19,6 @@
         "hayai": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@types/fs-extra": "^11.0.4",
         "@types/inquirer": "^9.0.8",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.16.0",
@@ -1787,16 +1785,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1848,15 +1836,6 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
-      }
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -3392,19 +3371,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3589,7 +3555,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -5184,17 +5151,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6498,14 +6454,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -76,13 +76,11 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^12.1.0",
-    "fs-extra": "^11.3.0",
     "inquirer": "^9.2.12",
     "ora": "^8.2.0",
     "yaml": "^2.8.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.8",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.16.0",

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -26,11 +26,6 @@ export const initCommand = new Command('init')
   .option('-n, --name <name>', 'Database instance name')
   .option('-e, --engine <engine>', 'Database engine (postgresql, mariadb, redis, etc.)')
   .option('-p, --port <port>', 'Custom port number', parseInt)
-  .option('--admin-dashboard', 'Enable admin dashboard')
-  .option('--no-admin-dashboard', 'Disable admin dashboard')
-  .option('--client-sdk', 'Generate client SDK')
-  .option('--no-client-sdk', 'Skip client SDK generation')
-  .option('--language <language>', 'Programming language for client SDK')
   .option('-y, --yes', 'Skip interactive prompts and use defaults')
   .action(async (options: InitOptions) => {
     try {
@@ -40,9 +35,6 @@ export const initCommand = new Command('init')
         name: string;
         engine: string;
         port?: number;
-        adminDashboard: boolean;
-        clientSdk: boolean;
-        language?: string;
       };
 
       if (options.yes && options.name && options.engine) {
@@ -51,9 +43,6 @@ export const initCommand = new Command('init')
           name: options.name,
           engine: options.engine,
           port: options.port,
-          adminDashboard: options.adminDashboard ?? true,
-          clientSdk: options.clientSdk ?? false,
-          language: options.language,
         };
         spinner.stop();
       } else {
@@ -120,35 +109,12 @@ export const initCommand = new Command('init')
             },
             filter: (input: string) => input ? parseInt(input) : undefined,
           },
-          {
-            type: 'confirm',
-            name: 'adminDashboard',
-            message: 'Enable admin dashboard?',
-            default: options.adminDashboard ?? true,
-          },
-          {
-            type: 'confirm',
-            name: 'clientSdk',
-            message: 'Generate client SDK?',
-            default: options.clientSdk ?? false,
-          },
-          {
-            type: 'list',
-            name: 'language',
-            message: 'Which programming language?',
-            choices: ['typescript', 'javascript', 'python'],
-            default: options.language || 'typescript',
-            when: (answers: any) => answers.clientSdk,
-          },
         ]);
 
         config = {
           name: answers.name,
           engine: options.engine || answers.engine,
           port: answers.port,
-          adminDashboard: answers.adminDashboard,
-          clientSdk: answers.clientSdk,
-          language: answers.language,
         };
       }
 
@@ -163,7 +129,6 @@ export const initCommand = new Command('init')
       
       const instance = await createDatabase(config.name, template, {
         port: config.port,
-        adminDashboard: config.adminDashboard,
       });
 
       createSpinner.succeed(`Successfully created ${template.name} instance '${config.name}'`);
@@ -185,11 +150,6 @@ export const initCommand = new Command('init')
       console.log(`  1. Run ${chalk.cyan('hayai start')} to start your database`);
       console.log(`  2. Run ${chalk.cyan('hayai list')} to see all your databases`);
       console.log(`  3. Run ${chalk.cyan('hayai studio')} to open admin dashboards`);
-      console.log(`  4. Check your ${chalk.cyan('.env')} file for connection details`);
-
-      if (config.clientSdk) {
-        console.log(`  5. Find your client SDK in ${chalk.cyan('./client/')} directory`);
-      }
 
     } catch (error) {
       console.error(chalk.red('\n❌ Failed to initialize database:'), error instanceof Error ? error.message : error);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -177,8 +177,8 @@ export const initCommand = new Command('init')
       console.log(`  Connection URI: ${chalk.cyan(instance.connection_uri)}`);
       console.log(`  Data Volume: ${chalk.gray(instance.volume)}`);
       
-      if (config.adminDashboard && template.admin_dashboard) {
-        console.log(`  Admin Dashboard: ${chalk.cyan(`http://localhost:${template.admin_dashboard.port}`)}`);
+      if (template.admin_dashboard?.enabled) {
+        console.log(`  Admin Dashboard: run ${chalk.cyan(`hayai studio ${instance.name}`)} once started`);
       }
 
       console.log(chalk.yellow('\n📋 Next Steps:'));

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { spawn } from 'child_process';
 import { getDockerManager } from '../../core/docker.js';
+import { getComposeFilePath } from '../../core/config.js';
 import { LogOptions } from '../../core/types.js';
 
 export const logsCommand = new Command('logs')
@@ -17,41 +19,42 @@ export const logsCommand = new Command('logs')
       const instance = dockerManager.getInstance(name);
       if (!instance) {
         console.error(chalk.red(`❌ Database instance '${name}' not found`));
+        console.log(chalk.yellow('💡 Run `hayai list` to see available databases'));
         process.exit(1);
       }
 
-      console.log(chalk.cyan(`📋 Logs for '${name}':`));
-      console.log(chalk.gray('─'.repeat(50)));
+      const composeFilePath = await getComposeFilePath();
+      const args = ['compose', '-f', composeFilePath, 'logs'];
 
-      // NOTE: Docker logs integration implementation pending
-      // Will use dockerode to stream real-time container logs
-      console.log(chalk.yellow('🚧 Docker logs integration coming soon!'));
-      console.log(chalk.gray('This will show real-time logs from the database container.'));
-      
+      if (options.follow) {
+        args.push('--follow');
+      }
+      if (options.tail !== undefined) {
+        args.push('--tail', String(options.tail));
+      }
+      if (options.since) {
+        args.push('--since', options.since);
+      }
+      args.push(`${name}-db`);
+
+      console.log(chalk.cyan(`📋 Logs for '${name}':`));
       if (options.follow) {
         console.log(chalk.gray('Following logs... (Press Ctrl+C to stop)'));
-        
-        // Simulate log following
-        const logEntries = [
-          '2024-01-07 12:00:00 [INFO] Database server starting...',
-          '2024-01-07 12:00:01 [INFO] Listening on port 5432',
-          '2024-01-07 12:00:02 [INFO] Database ready to accept connections',
-          '2024-01-07 12:00:03 [INFO] Connection established from 127.0.0.1',
-        ];
-
-        for (const entry of logEntries) {
-          console.log(chalk.gray(entry));
-          await new Promise(resolve => setTimeout(resolve, 1000));
-        }
       }
+      console.log(chalk.gray('─'.repeat(50)));
 
-      console.log(chalk.yellow('\n💡 Commands:'));
-      console.log('  • hayai logs <name> -f     - Follow logs in real-time');
-      console.log('  • hayai logs <name> -t 50  - Show last 50 lines');
-      console.log('  • hayai stop <name>        - Stop the database');
+      const child = spawn('docker', args, { stdio: 'inherit' });
 
+      child.on('error', (error) => {
+        console.error(chalk.red('\n❌ Failed to show logs:'), error.message);
+        process.exit(1);
+      });
+
+      child.on('close', (code) => {
+        process.exit(code ?? 0);
+      });
     } catch (error) {
       console.error(chalk.red('\n❌ Failed to show logs:'), error instanceof Error ? error.message : error);
       process.exit(1);
     }
-  }); 
+  });

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,58 +1,51 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import inquirer from 'inquirer';
-import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
-import { getTemplate } from '../../core/templates.js';
-import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { CLIOptions } from '../../core/types.js';
-import { spawn } from 'child_process';
-import fs from 'fs-extra';
 
 interface MigrateOptions extends CLIOptions {
   from: string;
   to: string;
   targetEngine: string;
-  confirm?: boolean;
-  force?: boolean;
   dryRun?: boolean;
 }
 
-// Expanded mapping of compatible migrations
+// Mapping of migration paths the planner understands. Execution is not
+// implemented yet — see showManualMigrationGuidance below.
 const MIGRATION_COMPATIBILITY: Record<string, string[]> = {
-  // Time Series Migrations (expanded)
+  // Time Series Migrations
   'influxdb2': ['influxdb3', 'victoriametrics', 'questdb'],
   'influxdb3': ['influxdb2', 'victoriametrics', 'questdb'],
   'timescaledb': ['influxdb2', 'influxdb3', 'questdb', 'victoriametrics'],
   'questdb': ['influxdb2', 'influxdb3', 'timescaledb', 'victoriametrics'],
   'victoriametrics': ['influxdb2', 'influxdb3', 'questdb'],
   'horaedb': ['influxdb2', 'influxdb3', 'questdb'],
-  
+
   // SQL Database Migrations
-  'postgresql': ['timescaledb'], // PostgreSQL can migrate to TimescaleDB
-  'mariadb': ['postgresql'], // MariaDB can migrate to PostgreSQL
-  
-  // Vector Database Migrations (expanded)
+  'postgresql': ['timescaledb'],
+  'mariadb': ['postgresql'],
+
+  // Vector Database Migrations
   'qdrant': ['milvus', 'weaviate'],
   'milvus': ['qdrant', 'weaviate'],
   'weaviate': ['qdrant', 'milvus'],
-  
-  // Search Engine Migrations (expanded)
+
+  // Search Engine Migrations
   'meilisearch': ['typesense'],
   'typesense': ['meilisearch'],
-  
+
   // Graph Database Migrations
-  'arangodb': ['nebula'], // ArangoDB can migrate to Nebula (conceptual)
-  'nebula': ['arangodb'], // Nebula can migrate to ArangoDB (conceptual)
-  
-  // Key-Value Migrations (expanded)
+  'arangodb': ['nebula'],
+  'nebula': ['arangodb'],
+
+  // Key-Value Migrations
   'redis': ['leveldb', 'lmdb', 'tikv'],
   'leveldb': ['lmdb', 'redis', 'tikv'],
   'lmdb': ['leveldb', 'redis', 'tikv'],
   'tikv': ['redis', 'leveldb', 'lmdb'],
-  
+
   // Wide Column Migrations
-  'cassandra': ['arangodb'], // Cassandra can migrate to ArangoDB in specific scenarios
+  'cassandra': ['arangodb'],
 };
 
 function validateMigrationCompatibility(sourceEngine: string, targetEngine: string): { compatible: boolean; reason?: string } {
@@ -62,7 +55,7 @@ function validateMigrationCompatibility(sourceEngine: string, targetEngine: stri
       reason: 'Source and target engines are the same. Use clone command instead.'
     };
   }
-  
+
   const compatibleTargets = MIGRATION_COMPATIBILITY[sourceEngine];
   if (!compatibleTargets || !compatibleTargets.includes(targetEngine)) {
     return {
@@ -70,90 +63,27 @@ function validateMigrationCompatibility(sourceEngine: string, targetEngine: stri
       reason: `Migration from '${sourceEngine}' to '${targetEngine}' is not supported`
     };
   }
-  
-  return { compatible: true };
-}
 
-function getMigrationStrategy(sourceEngine: string, targetEngine: string): string {
-  const key = `${sourceEngine}->${targetEngine}`;
-  
-  const strategies: Record<string, string> = {
-    // InfluxDB Family
-    'influxdb2->influxdb3': 'influx_line_protocol',
-    'influxdb3->influxdb2': 'influx_line_protocol',
-    'influxdb2->victoriametrics': 'influx_to_prometheus',
-    'influxdb3->victoriametrics': 'influx_to_prometheus',
-    'victoriametrics->influxdb2': 'prometheus_to_influx',
-    'victoriametrics->influxdb3': 'prometheus_to_influx',
-    
-    // SQL to Time Series
-    'timescaledb->influxdb2': 'sql_to_line_protocol',
-    'timescaledb->influxdb3': 'sql_to_line_protocol',
-    'timescaledb->questdb': 'postgres_to_questdb',
-    'questdb->influxdb2': 'sql_to_line_protocol',
-    'questdb->influxdb3': 'sql_to_line_protocol',
-    'questdb->timescaledb': 'questdb_to_postgres',
-    'horaedb->influxdb2': 'horaedb_to_influx',
-    'horaedb->influxdb3': 'horaedb_to_influx',
-    
-    // SQL Database Migrations
-    'postgresql->timescaledb': 'postgres_to_timescale',
-    'mariadb->postgresql': 'mysql_to_postgres',
-    
-    // Vector Databases
-    'qdrant->milvus': 'vector_export_import',
-    'milvus->qdrant': 'vector_export_import',
-    'qdrant->weaviate': 'vector_export_import',
-    'weaviate->qdrant': 'vector_export_import',
-    'milvus->weaviate': 'vector_export_import',
-    'weaviate->milvus': 'vector_export_import',
-    
-    // Graph Databases
-    'arangodb->nebula': 'graph_export_import',
-    'nebula->arangodb': 'graph_export_import',
-    
-    // Search Engines
-    'meilisearch->typesense': 'document_export_import',
-    'typesense->meilisearch': 'document_export_import',
-    
-    // Key-Value Migrations
-    'redis->leveldb': 'key_value_dump',
-    'redis->lmdb': 'key_value_dump',
-    'redis->tikv': 'redis_to_tikv',
-    'leveldb->lmdb': 'key_value_dump',
-    'leveldb->redis': 'key_value_dump',
-    'leveldb->tikv': 'leveldb_to_tikv',
-    'lmdb->leveldb': 'key_value_dump',
-    'lmdb->redis': 'key_value_dump',
-    'lmdb->tikv': 'lmdb_to_tikv',
-    'tikv->redis': 'tikv_to_redis',
-    'tikv->leveldb': 'tikv_to_leveldb',
-    'tikv->lmdb': 'tikv_to_lmdb',
-    
-    // Wide Column
-    'cassandra->arangodb': 'cassandra_to_arango',
-  };
-  
-  return strategies[key] || 'generic_export_import';
+  return { compatible: true };
 }
 
 function getMigrationComplexity(sourceEngine: string, targetEngine: string): 'low' | 'medium' | 'high' {
   const key = `${sourceEngine}->${targetEngine}`;
-  
+
   const complexityMap: Record<string, 'low' | 'medium' | 'high'> = {
     // Low complexity (same family/similar structure)
     'influxdb2->influxdb3': 'low',
     'influxdb3->influxdb2': 'low',
     'leveldb->lmdb': 'low',
     'lmdb->leveldb': 'low',
-    
+
     // Medium complexity (similar purpose, different format)
     'meilisearch->typesense': 'medium',
     'typesense->meilisearch': 'medium',
     'qdrant->milvus': 'medium',
     'milvus->qdrant': 'medium',
     'redis->leveldb': 'medium',
-    
+
     // High complexity (different paradigms)
     'timescaledb->influxdb2': 'high',
     'questdb->influxdb3': 'high',
@@ -161,16 +91,16 @@ function getMigrationComplexity(sourceEngine: string, targetEngine: string): 'lo
     'cassandra->arangodb': 'high',
     'arangodb->nebula': 'high',
   };
-  
+
   return complexityMap[key] || 'high';
 }
 
 function showMigrationWarnings(sourceEngine: string, targetEngine: string): void {
   const complexity = getMigrationComplexity(sourceEngine, targetEngine);
-  
+
   console.log(chalk.yellow('\n⚠️  Migration Warnings:'));
   console.log(chalk.gray(`Migration Complexity: ${complexity.toUpperCase()}`));
-  
+
   const warnings: Record<string, string[]> = {
     'timescaledb->influxdb2': [
       'TimescaleDB hypertables will be converted to InfluxDB measurements',
@@ -214,10 +144,10 @@ function showMigrationWarnings(sourceEngine: string, targetEngine: string): void
       'Partitioning strategies will not transfer'
     ]
   };
-  
+
   const key = `${sourceEngine}->${targetEngine}`;
   const specificWarnings = warnings[key];
-  
+
   if (specificWarnings) {
     specificWarnings.forEach(warning => {
       console.log(chalk.gray(`  • ${warning}`));
@@ -227,496 +157,83 @@ function showMigrationWarnings(sourceEngine: string, targetEngine: string): void
     console.log(chalk.gray('  • Schema and indexing configurations will need manual review'));
     console.log(chalk.gray('  • Performance characteristics may differ between engines'));
   }
-  
-  console.log(chalk.yellow('\n💡 Recommendations:'));
-  console.log(chalk.gray('  • Create full backup of source database before migration'));
-  console.log(chalk.gray('  • Test migration with a small dataset first'));
-  console.log(chalk.gray('  • Review migrated data for consistency and completeness'));
-  console.log(chalk.gray('  • Update application connections, queries, and configurations'));
-  console.log(chalk.gray('  • Monitor performance and optimize target database settings'));
-  
-  if (complexity === 'high') {
-    console.log(chalk.red('\n🚨 HIGH COMPLEXITY MIGRATION:'));
-    console.log(chalk.gray('  • Consider manual migration for critical production data'));
-    console.log(chalk.gray('  • Extensive testing and validation required'));
-    console.log(chalk.gray('  • Application logic may need significant changes'));
+}
+
+function showManualMigrationGuidance(sourceEngine: string, targetEngine: string): void {
+  console.log(chalk.yellow('\n💡 How to migrate manually:'));
+
+  const guidance: Record<string, string[]> = {
+    'influxdb2': [
+      'Export: docker exec <source>-db influx backup /tmp/backup',
+      'Or stream line protocol with influx query and write it to the target'
+    ],
+    'influxdb3': [
+      'Export: use the influxdb3 CLI or the /api/v3 query endpoints'
+    ],
+    'timescaledb': [
+      'Export: docker exec <source>-db pg_dump -U <user> -d <db> > dump.sql',
+      'Transform rows to the target format before importing'
+    ],
+    'postgresql': [
+      'Export: docker exec <source>-db pg_dump -U <user> -d <db> > dump.sql',
+      'Import into TimescaleDB, then convert tables with create_hypertable()'
+    ],
+    'mariadb': [
+      'Export: docker exec <source>-db mysqldump -u root <db> > dump.sql',
+      'Convert syntax with pgloader for a MariaDB → PostgreSQL move'
+    ],
+    'questdb': [
+      'Export: SELECT ... INTO OUTFILE or the /exp REST endpoint (CSV)'
+    ],
+    'victoriametrics': [
+      'Export: /api/v1/export (JSON lines) or vmctl for bulk moves'
+    ],
+    'qdrant': [
+      'Use the snapshots API: POST /collections/<name>/snapshots'
+    ],
+    'milvus': [
+      'Use the milvus-backup tool or collection export/import'
+    ],
+    'weaviate': [
+      'Use the backup API or cursor-based object export'
+    ],
+    'meilisearch': [
+      'Use the dumps API: POST /dumps, then import on the target'
+    ],
+    'typesense': [
+      'Export collections with GET /collections/<name>/documents/export'
+    ],
+    'arangodb': [
+      'Use arangodump + arangorestore, or arangoexport for graph data'
+    ],
+    'redis': [
+      'Use redis-cli --rdb to dump, or MIGRATE for live key transfer'
+    ],
+    'cassandra': [
+      'Use nodetool snapshot + sstableloader, or cqlsh COPY commands'
+    ],
+  };
+
+  const sourceSteps = guidance[sourceEngine];
+  if (sourceSteps) {
+    sourceSteps.forEach(step => console.log(chalk.gray(`  • ${step}`)));
+  } else {
+    console.log(chalk.gray(`  • Check the ${sourceEngine} documentation for native export tools`));
   }
+  console.log(chalk.gray(`  • Import the transformed data using ${targetEngine}'s native tooling`));
+  console.log(chalk.gray('  • Create a snapshot first: ') + chalk.cyan('hayai snapshot <name>'));
 }
 
-function logMigrationStep(step: string, detail?: string): void {
-  const timestamp = new Date().toLocaleTimeString();
-  console.log(chalk.gray(`[${timestamp}] 🔄 ${step}`));
-  if (detail) {
-    console.log(chalk.gray(`           ${detail}`));
-  }
-}
-
-async function executeMigration(sourceInstance: any, targetName: string, targetEngine: string): Promise<void> {
-  const dockerManager = getDockerManager();
-  
-  logMigrationStep('Starting migration process...', `${sourceInstance.engine} → ${targetEngine}`);
-  
-  // Get target template
-  const targetTemplate = getTemplate(targetEngine);
-  if (!targetTemplate) {
-    throw new Error(`Template not found for target engine: ${targetEngine}`);
-  }
-
-  logMigrationStep('Creating target database container...');
-
-  // Create target database
-  const targetInstance = await dockerManager.createDatabase(
-    targetName,
-    targetTemplate,
-    {
-      port: undefined, // Let it auto-allocate
-      adminDashboard: false,
-      customEnv: {}
-    }
-  );
-
-  logMigrationStep('Starting target database...', 'Waiting for initialization');
-
-  // Start target database
-  await dockerManager.startDatabase(targetName);
-
-  // Wait for database to be ready with progress
-  await waitForDatabaseReady(targetName, targetEngine, targetInstance.environment);
-
-  logMigrationStep('Executing migration strategy...', getMigrationStrategy(sourceInstance.engine, targetEngine));
-  
-  // Execute migration based on strategy
-  const strategy = getMigrationStrategy(sourceInstance.engine, targetEngine);
-  await executeMigrationStrategy(sourceInstance, targetName, targetEngine, strategy);
-  
-  logMigrationStep('Migration completed successfully!', `${sourceInstance.name} → ${targetName}`);
-}
-
-async function waitForDatabaseReady(
-  containerName: string,
-  engine: string,
-  environment: Record<string, string> = {}
-): Promise<void> {
-  const maxAttempts = 30;
-  const interval = 2000;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    logMigrationStep(`Health check (${attempt}/${maxAttempts})...`, `Checking ${engine} readiness`);
-
-    const isReady = await checkDatabaseHealth(containerName, engine, environment).catch(() => false);
-    if (isReady) {
-      logMigrationStep('Database is ready!', 'Health check passed');
-      return;
-    }
-
-    if (attempt < maxAttempts) {
-      await new Promise(resolve => setTimeout(resolve, interval));
-    }
-  }
-
-  throw new Error(`Database '${containerName}' failed to become ready after ${maxAttempts} attempts`);
-}
-
-async function checkDatabaseHealth(
-  containerName: string,
-  engine: string,
-  environment: Record<string, string> = {}
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    let healthCommand: string[] = [];
-
-    switch (engine) {
-      case 'postgresql':
-      case 'timescaledb': {
-        const { user, database } = getPostgresExecCredentials(environment);
-        healthCommand = ['docker', 'exec', `${containerName}-db`, 'pg_isready', '-U', user, '-d', database];
-        break;
-      }
-      case 'mariadb':
-        healthCommand = [
-          'docker', 'exec', '-e', `MYSQL_PWD=${getMariaDBRootPassword(environment)}`,
-          `${containerName}-db`, 'mysqladmin', 'ping', '-u', 'root'
-        ];
-        break;
-      case 'redis':
-        healthCommand = ['docker', 'exec', `${containerName}-db`, 'redis-cli', 'ping'];
-        break;
-      case 'influxdb2':
-      case 'influxdb3':
-        healthCommand = ['docker', 'exec', `${containerName}-db`, 'influx', 'ping'];
-        break;
-      default:
-        // Generic health check
-        healthCommand = ['docker', 'exec', `${containerName}-db`, 'echo', 'ready'];
-    }
-    
-    const healthProcess = spawn(healthCommand[0], healthCommand.slice(1), { 
-      stdio: ['ignore', 'ignore', 'ignore'] 
-    });
-    
-    healthProcess.on('close', (code) => {
-      resolve(code === 0);
-    });
-    
-    healthProcess.on('error', () => {
-      resolve(false);
-    });
-  });
-}
-
-async function executeMigrationStrategy(source: any, targetName: string, targetEngine: string, strategy: string): Promise<void> {
-  const sourceContainer = `${source.name}-db`;
-  const targetContainer = `${targetName}-db`;
-  
-  logMigrationStep(`Applying strategy: ${strategy}`, `From ${sourceContainer} to ${targetContainer}`);
-  
-  switch (strategy) {
-    case 'influx_line_protocol':
-      await migrateInfluxLineProtocol(sourceContainer, targetContainer);
-      break;
-    case 'influx_to_prometheus':
-      await migrateInfluxToPrometheus();
-      break;
-    case 'prometheus_to_influx':
-      await migratePrometheusToInflux();
-      break;
-    case 'sql_to_line_protocol':
-      await migrateSQLToLineProtocol(sourceContainer, targetContainer, source.engine, source.environment);
-      break;
-    case 'postgres_to_timescale':
-      await migratePostgresToTimescale();
-      break;
-    case 'mysql_to_postgres':
-      await migrateMySQLToPostgres();
-      break;
-    case 'vector_export_import':
-      await migrateVectorDatabase(sourceContainer, targetContainer, source.engine, targetEngine);
-      break;
-    case 'graph_export_import':
-      await migrateGraphDatabase(sourceContainer, targetContainer, source.engine, targetEngine);
-      break;
-    case 'document_export_import':
-      await migrateDocumentDatabase(sourceContainer, targetContainer, source.engine, targetEngine);
-      break;
-    case 'key_value_dump':
-      await migrateKeyValueDatabase(sourceContainer, targetContainer, source.engine, targetEngine);
-      break;
-    case 'redis_to_tikv':
-      await migrateRedisToTikv();
-      break;
-    case 'cassandra_to_arango':
-      await migrateCassandraToArango();
-      break;
-    default:
-      throw new Error(`Migration strategy '${strategy}' not implemented`);
-  }
-}
-
-// Implementations of actual migrations with detailed output
-
-async function migrateInfluxLineProtocol(sourceContainer: string, targetContainer: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    logMigrationStep('Exporting data using InfluxDB Line Protocol...');
-    
-    // List all buckets/databases first
-    const listBucketsProcess = spawn('docker', [
-      'exec', sourceContainer,
-      'influx', 'bucket', 'list'
-    ], { stdio: ['inherit', 'pipe', 'pipe'] });
-    
-    listBucketsProcess.on('close', (_code) => {
-      if (_code !== 0) {
-        logMigrationStep('Warning: Could not list buckets, using default query');
-      }
-      
-      logMigrationStep('Querying time series data...', 'Extracting measurements and series');
-      
-      // Export data from source
-      const exportProcess = spawn('docker', [
-        'exec', sourceContainer,
-        'influx', 'query', '--format', 'csv', 
-        'from(bucket:"_monitoring") |> range(start:-30d) |> limit(n:10000)'
-      ], { stdio: ['inherit', 'pipe', 'pipe'] });
-      
-      let exportedLines = 0;
-      exportProcess.stdout.on('data', (data) => {
-        const lines = data.toString().split('\n').filter((line: string) => line.trim());
-        exportedLines += lines.length;
-        logMigrationStep(`Exported ${exportedLines} data points...`);
-      });
-      
-      // Import to target
-      const importProcess = spawn('docker', [
-        'exec', '-i', targetContainer,
-        'influx', 'write', '--bucket', 'migrated-data', '--precision', 'ns'
-      ], { stdio: ['pipe', 'inherit', 'pipe'] });
-      
-      exportProcess.stdout.pipe(importProcess.stdin);
-      
-      importProcess.on('close', (importCode) => {
-        if (importCode === 0) {
-          logMigrationStep('Import completed successfully', `Total lines processed: ${exportedLines}`);
-          resolve();
-        } else {
-          reject(new Error('InfluxDB Line Protocol migration failed during import'));
-        }
-      });
-      
-      exportProcess.on('error', reject);
-      importProcess.on('error', reject);
-    });
-  });
-}
-
-async function migrateSQLToLineProtocol(
-  sourceContainer: string,
-  targetContainer: string,
-  sourceEngine: string,
-  sourceEnv: Record<string, string> = {}
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    logMigrationStep('Converting SQL data to Line Protocol format...');
-    
-    // Engine-specific SQL conversion
-    let conversionQuery = '';
-    if (sourceEngine === 'timescaledb') {
-      conversionQuery = `
-        SELECT 
-          schemaname || '_' || tablename || ',host=localhost ' ||
-          array_to_string(array_agg(column_name || '=' || 'value'), ',') || ' ' ||
-          extract(epoch from now()) * 1000000000 as line_protocol
-        FROM information_schema.columns 
-        WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
-        GROUP BY schemaname, tablename
-        LIMIT 1000;
-      `;
-    } else if (sourceEngine === 'questdb') {
-      conversionQuery = `
-        SELECT 
-          table_name || ',host=localhost value=1 ' ||
-          cast(systimestamp() as long) * 1000000 as line_protocol
-        FROM tables() 
-        LIMIT 1000;
-      `;
-    }
-    
-    logMigrationStep('Executing SQL conversion query...', `Engine: ${sourceEngine}`);
-    
-    // Export from SQL database
-    const { user, database } = getPostgresExecCredentials(sourceEnv);
-    const exportProcess = spawn('docker', [
-      'exec', sourceContainer,
-      'psql', '-U', user, '-d', database, '-t', '-c', conversionQuery
-    ], { stdio: ['inherit', 'pipe', 'pipe'] });
-    
-    let convertedRows = 0;
-    exportProcess.stdout.on('data', (data) => {
-      const lines = data.toString().split('\n').filter((line: string) => line.trim());
-      convertedRows += lines.length;
-      logMigrationStep(`Converted ${convertedRows} SQL rows...`);
-    });
-    
-    // Import to InfluxDB
-    const importProcess = spawn('docker', [
-      'exec', '-i', targetContainer,
-      'influx', 'write', '--bucket', 'sql-migrated-data'
-    ], { stdio: ['pipe', 'inherit', 'pipe'] });
-    
-    exportProcess.stdout.pipe(importProcess.stdin);
-    
-    importProcess.on('close', (code) => {
-      if (code === 0) {
-        logMigrationStep('SQL to Line Protocol migration completed', `Rows converted: ${convertedRows}`);
-        resolve();
-      } else {
-        reject(new Error('SQL to Line Protocol migration failed'));
-      }
-    });
-    
-    exportProcess.on('error', reject);
-    importProcess.on('error', reject);
-  });
-}
-
-async function migrateVectorDatabase(sourceContainer: string, targetContainer: string, sourceEngine: string, targetEngine: string): Promise<void> {
-  logMigrationStep('Exporting vector collections...', `From ${sourceEngine} to ${targetEngine}`);
-  
-  // Create temporary directory for vector data
-  const tempDir = '/tmp/hayai-vector-migration';
-  await fs.ensureDir(tempDir);
-  
-  logMigrationStep('Creating vector data export...', 'Extracting embeddings and metadata');
-  
-  // Simulate real vector database export with progress
-  let collectionsProcessed = 0;
-  const totalCollections = 3; // Mock number
-  
-  for (let i = 0; i < totalCollections; i++) {
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    collectionsProcessed++;
-    logMigrationStep(`Processing collection ${collectionsProcessed}/${totalCollections}...`, 
-      `Extracting vectors and payloads`);
-  }
-  
-  logMigrationStep('Converting vector formats...', 'Transforming embeddings for target engine');
-  await new Promise(resolve => setTimeout(resolve, 2000));
-  
-  logMigrationStep('Importing to target vector database...', 'Rebuilding indexes');
-  await new Promise(resolve => setTimeout(resolve, 2000));
-  
-  logMigrationStep('Vector migration completed', `${collectionsProcessed} collections migrated`);
-  
-  // Cleanup
-  await fs.remove(tempDir);
-}
-
-async function migrateGraphDatabase(sourceContainer: string, targetContainer: string, sourceEngine: string, targetEngine: string): Promise<void> {
-  logMigrationStep('Exporting graph data...', `${sourceEngine} → ${targetEngine}`);
-  
-  logMigrationStep('Extracting vertices and edges...', 'Processing graph topology');
-  await new Promise(resolve => setTimeout(resolve, 2000));
-  
-  logMigrationStep('Converting graph schema...', 'Transforming data model');
-  await new Promise(resolve => setTimeout(resolve, 1500));
-  
-  logMigrationStep('Importing graph structure...', 'Rebuilding relationships');
-  await new Promise(resolve => setTimeout(resolve, 2500));
-  
-  logMigrationStep('Graph migration completed', 'Topology preserved');
-}
-
-async function migrateDocumentDatabase(sourceContainer: string, targetContainer: string, sourceEngine: string, targetEngine: string): Promise<void> {
-  logMigrationStep('Exporting search indexes...', `${sourceEngine} → ${targetEngine}`);
-  
-  logMigrationStep('Extracting documents and schemas...', 'Processing search indexes');
-  await new Promise(resolve => setTimeout(resolve, 1500));
-  
-  logMigrationStep('Converting search configurations...', 'Transforming analyzers and filters');
-  await new Promise(resolve => setTimeout(resolve, 2000));
-  
-  logMigrationStep('Rebuilding search indexes...', 'Optimizing for target engine');
-  await new Promise(resolve => setTimeout(resolve, 3000));
-  
-  logMigrationStep('Document migration completed', 'Search functionality restored');
-}
-
-async function migrateKeyValueDatabase(sourceContainer: string, targetContainer: string, sourceEngine: string, targetEngine: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    logMigrationStep('Dumping key-value pairs...', `${sourceEngine} → ${targetEngine}`);
-    
-    if (sourceEngine === 'redis') {
-      // Real Redis dump implementation
-      const dumpProcess = spawn('docker', [
-        'exec', sourceContainer,
-        'redis-cli', '--scan', '--pattern', '*'
-      ], { stdio: ['inherit', 'pipe', 'pipe'] });
-      
-      let keysCount = 0;
-      dumpProcess.stdout.on('data', (data) => {
-        const keys = data.toString().split('\n').filter((k: string) => k.trim());
-        keysCount += keys.length;
-        logMigrationStep(`Scanned ${keysCount} keys...`);
-      });
-      
-      dumpProcess.on('close', (code) => {
-        if (code === 0) {
-          logMigrationStep('Key-value migration completed', `${keysCount} keys processed`);
-          resolve();
-        } else {
-          reject(new Error('Redis key scan failed'));
-        }
-      });
-      
-      dumpProcess.on('error', reject);
-    } else {
-      // Generic key-value migration
-      setTimeout(() => {
-        logMigrationStep('Key-value migration completed', 'Generic implementation');
-        resolve();
-      }, 2000);
-    }
-  });
-}
-
-// New specific implementations
-
-async function migrateInfluxToPrometheus(): Promise<void> {
-  return new Promise((resolve) => {
-    logMigrationStep('Converting InfluxDB to Prometheus format...');
-    
-    setTimeout(() => {
-      logMigrationStep('InfluxDB to Prometheus migration completed');
-      resolve();
-    }, 3000);
-  });
-}
-
-async function migratePrometheusToInflux(): Promise<void> {
-  return new Promise((resolve) => {
-    logMigrationStep('Converting Prometheus to InfluxDB format...');
-    
-    setTimeout(() => {
-      logMigrationStep('Prometheus to InfluxDB migration completed');
-      resolve();
-    }, 3000);
-  });
-}
-
-async function migratePostgresToTimescale(): Promise<void> {
-  return new Promise((resolve) => {
-    logMigrationStep('Migrating PostgreSQL to TimescaleDB...');
-    logMigrationStep('Creating hypertables...', 'Converting time-series tables');
-    
-    setTimeout(() => {
-      logMigrationStep('PostgreSQL to TimescaleDB migration completed');
-      resolve();
-    }, 4000);
-  });
-}
-
-async function migrateMySQLToPostgres(): Promise<void> {
-  return new Promise((resolve) => {
-    logMigrationStep('Migrating MariaDB/MySQL to PostgreSQL...');
-    logMigrationStep('Converting data types...', 'Transforming SQL syntax');
-    
-    setTimeout(() => {
-      logMigrationStep('MariaDB to PostgreSQL migration completed');
-      resolve();
-    }, 5000);
-  });
-}
-
-async function migrateRedisToTikv(): Promise<void> {
-  return new Promise((resolve) => {
-    logMigrationStep('Migrating Redis to TiKV...');
-    logMigrationStep('Converting Redis data structures...', 'Adapting to TiKV key-value model');
-    
-    setTimeout(() => {
-      logMigrationStep('Redis to TiKV migration completed');
-      resolve();
-    }, 3500);
-  });
-}
-
-async function migrateCassandraToArango(): Promise<void> {
-  return new Promise((resolve) => {
-    logMigrationStep('Migrating Cassandra to ArangoDB...');
-    logMigrationStep('Converting wide column to document model...', 'Transforming data structure');
-    
-    setTimeout(() => {
-      logMigrationStep('Cassandra to ArangoDB migration completed');
-      resolve();
-    }, 6000);
-  });
-}
-
-// Continue with handleMigrate function...
 async function handleMigrate(options: MigrateOptions): Promise<void> {
+  if (!options.from || !options.to || !options.targetEngine) {
+    console.error(chalk.red('❌ --from, --to, and --target-engine are required'));
+    console.log(chalk.yellow('💡 Example: hayai migrate -f source-db -t target-db -e influxdb3 --dry-run'));
+    process.exit(1);
+  }
+
   const dockerManager = getDockerManager();
   await dockerManager.initialize();
-  
-  logMigrationStep('Initializing migration process...', 'Validating source and target');
-  
+
   // Validate source database
   const sourceInstance = dockerManager.getInstance(options.from);
   if (!sourceInstance) {
@@ -724,181 +241,74 @@ async function handleMigrate(options: MigrateOptions): Promise<void> {
     console.log(chalk.yellow('💡 Run `hayai list` to see available databases'));
     process.exit(1);
   }
-  
-  // Check if source is running
-  if (sourceInstance.status !== 'running') {
-    console.error(chalk.red(`❌ Source database '${options.from}' must be running`));
-    console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${options.from}`)}`));
-    process.exit(1);
-  }
 
   // Validate migration compatibility
   const compatibilityResult = validateMigrationCompatibility(sourceInstance.engine, options.targetEngine);
   if (!compatibilityResult.compatible) {
     console.error(chalk.red(`❌ Migration not supported: ${compatibilityResult.reason}`));
-    console.log(chalk.yellow('\n💡 Supported migrations:'));
-    
+    console.log(chalk.yellow('\n💡 Supported migration paths:'));
+
     Object.entries(MIGRATION_COMPATIBILITY).forEach(([source, targets]) => {
       console.log(chalk.gray(`  ${chalk.cyan(source)} → ${targets.map(t => chalk.green(t)).join(', ')}`));
     });
-    
+
     process.exit(1);
   }
-  
-  // Check if target exists
-  if (dockerManager.getInstance(options.to)) {
-    if (!options.force) {
-      console.error(chalk.red(`❌ Target database '${options.to}' already exists`));
-      console.log(chalk.yellow('💡 Use --force to overwrite existing database'));
-      process.exit(1);
-    }
-  }
-  
-  // Show migration preview
-  console.log(chalk.cyan('\n🔍 Migration Preview:'));
+
+  // Show migration plan
+  console.log(chalk.cyan('\n🔍 Migration Plan:'));
   console.log(chalk.gray(`Source: ${options.from} (${chalk.cyan(sourceInstance.engine)})`));
   console.log(chalk.gray(`Target: ${options.to} (${chalk.cyan(options.targetEngine)})`));
-  console.log(chalk.gray(`Strategy: ${chalk.yellow(getMigrationStrategy(sourceInstance.engine, options.targetEngine))}`));
   console.log(chalk.gray(`Complexity: ${chalk.magenta(getMigrationComplexity(sourceInstance.engine, options.targetEngine).toUpperCase())}`));
-  
-  // Show warnings
+
   showMigrationWarnings(sourceInstance.engine, options.targetEngine);
-  
+
   if (options.dryRun) {
-    console.log(chalk.yellow('\n🚧 Dry run - no actual migration performed'));
-    logMigrationStep('Migration preview completed', 'No changes made to databases');
+    console.log(chalk.yellow('\n🚧 Dry run — plan shown above, nothing executed'));
     return;
   }
-  
-  // Confirmation
-  if (!options.confirm && !options.force) {
-    const { proceed } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'proceed',
-        message: `Migrate ${options.from} (${sourceInstance.engine}) to ${options.to} (${options.targetEngine})?`,
-        default: false,
-      },
-    ]);
-    
-    if (!proceed) {
-      console.log(chalk.yellow('Migration cancelled'));
-      return;
-    }
-  }
-  
-  // Execute migration
-  const spinner = ora('Preparing migration...').start();
-  
-  try {
-    // Remove existing target if force
-    if (options.force && dockerManager.getInstance(options.to)) {
-      spinner.text = 'Removing existing target database...';
-      logMigrationStep('Removing existing target database...', options.to);
-      await dockerManager.removeDatabase(options.to);
-    }
-    
-    spinner.stop();
-    console.log(chalk.cyan('\n🚀 Starting Migration Process\n'));
-    
-    await executeMigration(sourceInstance, options.to, options.targetEngine);
-    
-    console.log(chalk.green('\n✅ Migration completed successfully!'));
-    console.log(chalk.yellow('\n⚠️  Post-migration checklist:'));
-    console.log(chalk.gray('  ✓ Test data integrity and completeness'));
-    console.log(chalk.gray('  ✓ Update application connection strings'));
-    console.log(chalk.gray('  ✓ Adjust queries for target engine syntax'));
-    console.log(chalk.gray('  ✓ Monitor performance and optimize as needed'));
-    console.log(chalk.gray('  ✓ Update monitoring and alerting configurations'));
-    
-    console.log(`\n💡 Next steps:`);
-    console.log(`  • ${chalk.cyan(`hayai list`)} - View all databases`);
-    console.log(`  • ${chalk.cyan(`hayai studio ${options.to}`)} - Open target database dashboard`);
-    console.log(`  • ${chalk.cyan(`hayai logs ${options.to}`)} - Monitor target database logs`);
-    
-  } catch (error) {
-    spinner.fail('Migration failed');
-    console.error(chalk.red('\n❌ Migration failed:'), error instanceof Error ? error.message : error);
-    console.log(chalk.yellow('\n💡 Troubleshooting:'));
-    console.log(chalk.gray('  • Check source database connectivity and status'));
-    console.log(chalk.gray('  • Verify data formats and schemas compatibility'));
-    console.log(chalk.gray('  • Review migration logs for specific errors'));
-    console.log(chalk.gray('  • Ensure sufficient disk space and memory'));
-    console.log(chalk.gray('  • Check Docker container health and networking'));
-    process.exit(1);
-  }
+
+  // Automated execution is not implemented. Say so instead of pretending.
+  console.error(chalk.red('\n❌ Automated migration execution is not implemented yet'));
+  console.log(chalk.gray('This command currently validates compatibility and plans the migration.'));
+  showManualMigrationGuidance(sourceInstance.engine, options.targetEngine);
+  process.exit(1);
 }
 
 export const migrateCommand = new Command('migrate')
-  .description('Migrate data between compatible database engines')
+  .description('Plan a migration between compatible database engines')
   .option('-f, --from <name>', 'Source database name')
   .option('-t, --to <name>', 'Target database name')
   .option('-e, --target-engine <engine>', 'Target database engine')
-  .option('-y, --confirm', 'Skip confirmation prompt')
-  .option('--force', 'Overwrite existing target database')
-  .option('--dry-run', 'Show migration plan without executing')
+  .option('--dry-run', 'Show the migration plan')
   .option('--verbose', 'Enable verbose output')
   .addHelpText('after', `
-${chalk.bold('Supported Migrations:')}
+${chalk.bold('Status:')}
+  ${chalk.yellow('⚠️  Automated execution is not implemented yet.')}
+  This command validates compatibility, shows the plan and risks, and
+  points to the native tooling for performing the migration manually.
 
-${chalk.cyan('Time Series Databases:')}
-  ${chalk.green('✅ influxdb2')} ↔ ${chalk.green('influxdb3')} ↔ ${chalk.green('victoriametrics')} ↔ ${chalk.green('questdb')}
-  ${chalk.green('✅ timescaledb')} → ${chalk.green('influxdb2/3')}, ${chalk.green('questdb')}, ${chalk.green('victoriametrics')}
-  ${chalk.green('✅ horaedb')} → ${chalk.green('influxdb2/3')}, ${chalk.green('questdb')}
+${chalk.bold('Planned Migration Paths:')}
 
-${chalk.cyan('SQL Database Migrations:')}
-  ${chalk.green('✅ postgresql')} → ${chalk.green('timescaledb')}
-  ${chalk.green('✅ mariadb')} → ${chalk.green('postgresql')}
-
-${chalk.cyan('Vector Databases:')}
-  ${chalk.green('✅ qdrant')} ↔ ${chalk.green('milvus')} ↔ ${chalk.green('weaviate')}  (Vector Export/Import)
-
-${chalk.cyan('Graph Databases:')}
-  ${chalk.green('✅ arangodb')} ↔ ${chalk.green('nebula')}  (Graph Export/Import)
-
-${chalk.cyan('Search Engines:')}
-  ${chalk.green('✅ meilisearch')} ↔ ${chalk.green('typesense')}  (Document Export/Import)
-
-${chalk.cyan('Key-Value Stores:')}
-  ${chalk.green('✅ redis')} ↔ ${chalk.green('leveldb')} ↔ ${chalk.green('lmdb')} ↔ ${chalk.green('tikv')}  (Key-Value Dump)
-
-${chalk.cyan('Wide Column:')}
-  ${chalk.green('✅ cassandra')} → ${chalk.green('arangodb')}  (Schema Transformation)
+${chalk.cyan('Time Series:')}    influxdb2 ↔ influxdb3 ↔ victoriametrics ↔ questdb,
+                 timescaledb/horaedb → influxdb2/3, questdb
+${chalk.cyan('SQL:')}            postgresql → timescaledb, mariadb → postgresql
+${chalk.cyan('Vector:')}         qdrant ↔ milvus ↔ weaviate
+${chalk.cyan('Graph:')}          arangodb ↔ nebula
+${chalk.cyan('Search:')}         meilisearch ↔ typesense
+${chalk.cyan('Key-Value:')}      redis ↔ leveldb ↔ lmdb ↔ tikv
+${chalk.cyan('Wide Column:')}    cassandra → arangodb
 
 ${chalk.bold('Examples:')}
-  ${chalk.cyan('# Migrate InfluxDB 2.x to 3.x')}
-  hayai migrate -f influx2-prod -t influx3-prod -e influxdb3
+  ${chalk.cyan('# Check whether a migration path is supported and see the plan')}
+  hayai migrate -f influx2-prod -t influx3-prod -e influxdb3 --dry-run
 
-  ${chalk.cyan('# Migrate TimescaleDB to InfluxDB')}
+  ${chalk.cyan('# Same, with manual migration guidance for the engines involved')}
   hayai migrate -f timescale-metrics -t influx-metrics -e influxdb2
-
-  ${chalk.cyan('# Migrate PostgreSQL to TimescaleDB')}
-  hayai migrate -f postgres-app -t timescale-app -e timescaledb
-
-  ${chalk.cyan('# Migrate vector databases')}
-  hayai migrate -f qdrant-vectors -t milvus-vectors -e milvus -y
-
-  ${chalk.cyan('# Migrate Redis to TiKV')}
-  hayai migrate -f redis-cache -t tikv-cache -e tikv
-
-  ${chalk.cyan('# Preview migration (dry run)')}
-  hayai migrate -f questdb-data -t influx-data -e influxdb3 --dry-run
 
 ${chalk.bold('Migration Complexity:')}
   ${chalk.green('🟢 LOW:')}     Same family engines (influxdb2 → influxdb3)
   ${chalk.yellow('🟡 MEDIUM:')}  Similar purpose (qdrant → milvus)
   ${chalk.red('🔴 HIGH:')}     Different paradigms (timescaledb → influxdb2)
-
-${chalk.bold('Migration Notes:')}
-  ${chalk.yellow('⚠️  Data format conversion may result in some information loss')}
-  ${chalk.yellow('⚠️  Schema and indexing configurations will need manual review')}
-  ${chalk.yellow('⚠️  Always create full backup before migration')}
-  ${chalk.yellow('⚠️  Test with small datasets first')}
-  ${chalk.yellow('⚠️  High complexity migrations require extensive validation')}
-
-${chalk.bold('Not supported:')}
-  ${chalk.red('❌ Cross-category migrations without logical path')}
-  ${chalk.red('❌ Engines with fundamentally incompatible data models')}
-  ${chalk.red('❌ Migrations that would result in significant data loss')}
 `)
-  .action(handleMigrate); 
+  .action(handleMigrate);

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -302,7 +302,6 @@ export const snapshotCommand = new Command('snapshot')
       console.log(chalk.green('\n✅ Snapshot completed!'));
       console.log(chalk.yellow('💡 Commands:'));
       console.log(`  • ${chalk.cyan('hayai snapshot list')} - View all snapshots`);
-      console.log(`  • ${chalk.cyan('hayai snapshot restore')} - Restore from snapshot`);
 
     } catch (error) {
       console.error(chalk.red('❌ Snapshot failed:'), error instanceof Error ? error.message : error);
@@ -378,7 +377,7 @@ snapshotCommand
 
       console.log(chalk.yellow('💡 Commands:'));
       console.log(`  • ${chalk.cyan('hayai snapshot <name>')} - Create new snapshot`);
-      console.log(`  • ${chalk.cyan('hayai snapshot restore <file>')} - Restore from snapshot`);
+      console.log(`  • ${chalk.cyan('hayai snapshot clean')} - Remove old snapshots`);
 
     } catch (error) {
       console.error(chalk.red('❌ Failed to list snapshots:'), error instanceof Error ? error.message : error);

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -72,9 +72,11 @@ export const studioCommand = new Command('studio')
       for (const instance of validInstances) {
         const template = getTemplate(instance.engine);
         
-        if (template?.admin_dashboard?.enabled) {
-          const dashboardPort = options.port || template.admin_dashboard.port;
-          const dashboardUrl = `http://localhost:${dashboardPort}`;
+        if (template?.admin_dashboard?.enabled && instance.port > 0) {
+          // The dashboard is served by the database container itself, so it
+          // lives on the instance's published host port.
+          const dashboardPort = options.port || instance.port;
+          const dashboardUrl = `http://localhost:${dashboardPort}${template.admin_dashboard.path || ''}`;
           
           console.log(`${chalk.bold(instance.name)} (${template.name})`);
           console.log(`  Dashboard: ${chalk.cyan(dashboardUrl)}`);
@@ -134,22 +136,8 @@ export const studioCommand = new Command('studio')
 
         console.log(chalk.yellow('\n💡 Tips:'));
         console.log('  • Use connection details from `hayai list` to connect');
-        console.log('  • Default credentials are usually admin/password');
         console.log('  • Add `--no-open` to prevent auto-opening browser');
         console.log('  • Add `--check-ports` to verify dashboard accessibility');
-
-        // Show database-specific tips
-        const uniqueEngines = [...new Set(dashboardUrls.map(d => d.engine))];
-        if (uniqueEngines.includes('PostgreSQL')) {
-          console.log(chalk.blue('\n🐘 PostgreSQL Tips:'));
-          console.log('  • Use pgAdmin dashboard for advanced management');
-          console.log('  • Connect with: Host=localhost, Database=database, User=admin');
-        }
-        if (uniqueEngines.includes('Redis')) {
-          console.log(chalk.red('\n🔴 Redis Tips:'));
-          console.log('  • Use Redis Commander for data exploration');
-          console.log('  • Connect with: localhost:6379 (no password by default)');
-        }
 
       } else {
         console.log(chalk.yellow('⚠ No dashboards available'));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,7 +56,7 @@ ${chalk.bold('EXAMPLES')}
   ${chalk.cyan('hayai studio')}
   
   ${chalk.gray('# Create Redis cache for development')}
-  ${chalk.cyan('hayai init -n cache -e redis --admin-dashboard -y')}
+  ${chalk.cyan('hayai init -n cache -e redis -y')}
   
   ${chalk.gray('# Clone database for testing')}
   ${chalk.cyan('hayai clone --from prod --to staging')}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -100,7 +100,6 @@ program
   .version(version, '-v, --version', 'output the current version')
   .option('--verbose', 'Enable verbose logging')
   .option('-q, --quiet', 'Suppress output except errors')
-  .option('--config <path>', 'Path to configuration file')
   .configureHelp({
     formatHelp: () => {
       return helpText + `
@@ -127,7 +126,6 @@ ${chalk.bold('OPTIONS')}
   ${chalk.cyan('-v, --version')}       Output the current version
   ${chalk.cyan('--verbose')}          Enable verbose logging
   ${chalk.cyan('-q, --quiet')}        Suppress output except errors
-  ${chalk.cyan('--config <path>')}    Path to configuration file
   ${chalk.cyan('-h, --help')}         Display help for command
 `;
     }

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -26,15 +26,6 @@ export class DatabaseTemplates {
           retries: 5,
         },
       },
-      admin_dashboard: {
-        enabled: true,
-        port: 8080,
-        image: 'adminer:4.8.1',
-      },
-      client_sdk: {
-        enabled: true,
-        languages: ['typescript', 'python', 'javascript'],
-      },
     });
 
     this.addTemplate('mariadb', {
@@ -58,11 +49,6 @@ export class DatabaseTemplates {
           timeout: '5s',
           retries: 5,
         },
-      },
-      admin_dashboard: {
-        enabled: true,
-        port: 8080,
-        image: 'adminer:4.8.1',
       },
     });
 
@@ -111,11 +97,6 @@ export class DatabaseTemplates {
           timeout: '3s',
           retries: 5,
         },
-      },
-      admin_dashboard: {
-        enabled: true,
-        port: 8081,
-        image: 'rediscommander/redis-commander:latest',
       },
     });
 
@@ -217,8 +198,7 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 6333,
-        image: 'qdrant/qdrant:v1.7.0',
+        path: '/dashboard',
       },
     });
 
@@ -292,8 +272,6 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 8529,
-        image: 'arangodb:3.11',
       },
     });
 
@@ -316,11 +294,6 @@ export class DatabaseTemplates {
           timeout: '10s',
           retries: 5,
         },
-      },
-      admin_dashboard: {
-        enabled: true,
-        port: 7001,
-        image: 'vesoft/nebula-studio:v3.8.0',
       },
     });
 
@@ -347,8 +320,6 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 7700,
-        image: 'getmeili/meilisearch:v1.5',
       },
     });
 
@@ -398,12 +369,6 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 8086,
-        image: 'influxdb:latest',
-      },
-      client_sdk: {
-        enabled: true,
-        languages: ['typescript', 'python', 'javascript', 'go'],
       },
     });
 
@@ -433,12 +398,6 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 8086,
-        image: 'influxdb:2.7-alpine',
-      },
-      client_sdk: {
-        enabled: true,
-        languages: ['typescript', 'python', 'javascript', 'go', 'java'],
       },
     });
 
@@ -462,15 +421,6 @@ export class DatabaseTemplates {
           timeout: '5s',
           retries: 5,
         },
-      },
-      admin_dashboard: {
-        enabled: true,
-        port: 8080,
-        image: 'adminer:4.8.1',
-      },
-      client_sdk: {
-        enabled: true,
-        languages: ['typescript', 'python', 'javascript', 'go', 'rust'],
       },
     });
 
@@ -497,12 +447,6 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 9000,
-        image: 'questdb/questdb:latest',
-      },
-      client_sdk: {
-        enabled: true,
-        languages: ['typescript', 'python', 'javascript', 'java', 'go'],
       },
     });
 
@@ -528,8 +472,7 @@ export class DatabaseTemplates {
       },
       admin_dashboard: {
         enabled: true,
-        port: 8428,
-        image: 'victoriametrics/victoria-metrics:latest',
+        path: '/vmui',
       },
     });
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -72,14 +72,12 @@ export interface DatabaseInstance {
 export interface DatabaseTemplate {
   name: string;
   engine: DatabaseEngine;
+  // Web UI served by the database container itself, reachable on the
+  // instance's published port. Engines whose dashboards would require a
+  // separate container (adminer, redis-commander, ...) don't declare one.
   admin_dashboard?: {
     enabled: boolean;
-    port: number;
-    image: string;
-  };
-  client_sdk?: {
-    enabled: boolean;
-    languages: string[];
+    path?: string;
   };
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -122,9 +122,6 @@ export interface InitOptions extends CLIOptions {
   engine: string;
   port?: number;
   volume?: string;
-  adminDashboard?: boolean;
-  clientSdk?: boolean;
-  language?: string;
   yes?: boolean;
 }
 


### PR DESCRIPTION
P1 honesty work from the code audit: hayai no longer fabricates output or advertises capabilities that don't exist. Net **−1,100 lines**.

## Changes

- **logs** — was a 'coming soon' stub that printed hardcoded fake log lines under `--follow`. Now a real `docker compose logs` passthrough with `--follow`, `--tail`, `--since`.
- **migrate** — most strategies were `setTimeout` loops printing fabricated progress and a success message while moving no data; the rest were broken (annotated CSV piped into a line-protocol writer, key scans that wrote nothing). The command now keeps everything that was real — compatibility validation, plan/complexity/risk preview, `--dry-run` — and refuses to execute, printing engine-specific manual migration guidance instead. Drops ~600 lines of simulation. (Real execution can return path-by-path, with tests, per audit follow-ups.)
- **studio** — printed and auto-opened URLs for adminer/redis-commander/nebula-studio containers that are never created, on container-default ports. Templates now declare a dashboard only when the database container serves its own web UI (qdrant, arangodb, meilisearch, influxdb2/3, questdb, victoriametrics), and URLs are built from the instance's **actual published port** plus the UI path (e.g. `:<port>/dashboard` for Qdrant, `/vmui` for VictoriaMetrics).
- **init** — removed the client-SDK prompts/flags (nothing generates SDKs), the `.env` hint (nothing writes one), and the silently-dropped `--admin-dashboard` flags.
- **snapshot** — stopped suggesting the nonexistent `hayai snapshot restore`.
- **cli** — removed the parsed-but-never-read global `--config`.
- **deps** — dropped `fs-extra` (its only consumer was the simulated vector migration).

## Verification

- `npm run build` / `npm test` (7/7) / `npm run lint` — all clean
- CLI smoke: `--version`, `migrate --help`, `logs --help`

## Remaining P1 follow-ups (separate PRs)

- Embedded engines (sqlite/duckdb/leveldb/lmdb) run `alpine:latest` with no process — restart loops by design
- Security layer (SecurityManager) still unwired from clone/merge/migrate; SECURITY.md overclaims
- Redis merge still uses text-mangled `DUMP`/`RESTORE`