### PR TITLE
fix: manage embedded engines as host files instead of broken containers

### DIFF
--- a/src/cli/commands/clone.ts
+++ b/src/cli/commands/clone.ts
@@ -7,6 +7,7 @@ import { getTemplate } from '../../core/templates.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { CLIOptions } from '../../core/types.js';
 import { spawn } from 'child_process';
+import { cp } from 'fs/promises';
 
 interface CloneOptions extends CLIOptions {
   from: string;
@@ -17,14 +18,18 @@ interface CloneOptions extends CLIOptions {
   dryRun?: boolean;
 }
 
-// Engines totalmente compatíveis com implementação nativa específica
+// Engines with a reliable native clone implementation
 const FULLY_COMPATIBLE_ENGINES = new Set([
-  'postgresql',  // pg_dump + psql (nativo)
-  'mariadb',     // mysqldump + mysql (nativo)
-  'redis',       // BGSAVE + RDB copy (nativo)
-  'sqlite',      // File copy (confiável)
-  'duckdb'       // File copy (confiável)
+  'postgresql',  // pg_dump + psql
+  'mariadb',     // mysqldump + mysql
+  'redis',       // BGSAVE + RDB copy
+  'sqlite',      // host file copy (embedded)
+  'duckdb',      // host file copy (embedded)
+  'leveldb',     // host file copy (embedded)
+  'lmdb'         // host file copy (embedded)
 ]);
+
+const EMBEDDED_ENGINES = new Set(['sqlite', 'duckdb', 'leveldb', 'lmdb']);
 
 function validateCloneCompatibility(sourceEngine: string): { compatible: boolean; reason?: string } {
   if (!FULLY_COMPATIBLE_ENGINES.has(sourceEngine)) {
@@ -95,32 +100,39 @@ async function executeClone(sourceInstance: any, targetName: string): Promise<vo
   console.log(chalk.cyan(`🔄 Cloning ${sourceInstance.name} → ${targetName}...`));
   
   // Create target database with same configuration
-  await dockerManager.createDatabase(
+  const targetInstance = await dockerManager.createDatabase(
     targetName,
     sourceTemplate,
     {
       port: undefined, // Let it auto-allocate
-      adminDashboard: false,
       customEnv: { ...sourceInstance.environment }
     }
   );
 
-  // Start target database
-  await dockerManager.startDatabase(targetName);
-  
-  // Wait for database to be ready
-  await new Promise(resolve => setTimeout(resolve, 3000));
+  if (targetInstance.status !== 'embedded') {
+    // Start target database
+    await dockerManager.startDatabase(targetName);
+
+    // Wait for database to be ready
+    await new Promise(resolve => setTimeout(resolve, 3000));
+  }
 
   // Clone data based on database type
-  await cloneData(sourceInstance, targetName);
+  await cloneData(sourceInstance, targetInstance);
   
   console.log(chalk.green(`✅ Successfully cloned ${sourceInstance.name} → ${targetName}`));
 }
 
-async function cloneData(source: any, targetName: string): Promise<void> {
+async function cloneData(source: any, target: any): Promise<void> {
   const sourceContainer = `${source.name}-db`;
-  const targetContainer = `${targetName}-db`;
-  
+  const targetContainer = `${target.name}-db`;
+
+  if (EMBEDDED_ENGINES.has(source.engine)) {
+    // Embedded engines are host files — copy the data directory directly
+    await cp(source.volume, target.volume, { recursive: true, force: true });
+    return;
+  }
+
   switch (source.engine) {
     case 'postgresql':
       await clonePostgreSQL(sourceContainer, targetContainer, source.environment);
@@ -130,10 +142,6 @@ async function cloneData(source: any, targetName: string): Promise<void> {
       break;
     case 'redis':
       await cloneRedis(sourceContainer, targetContainer);
-      break;
-    case 'sqlite':
-    case 'duckdb':
-      await cloneFileDB(sourceContainer, targetContainer);
       break;
     default:
       // This situation should never happen due to compatibility validation
@@ -261,35 +269,6 @@ async function cloneRedis(sourceContainer: string, targetContainer: string): Pro
   });
 }
 
-async function cloneFileDB(sourceContainer: string, targetContainer: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    // Copy database file
-    const copyProcess = spawn('docker', [
-      'cp', `${sourceContainer}:/data/database.db`, '/tmp/hayai-clone.db'
-    ]);
-    
-    copyProcess.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error('Failed to copy database file'));
-        return;
-      }
-      
-      // Restore to target
-      const restoreProcess = spawn('docker', [
-        'cp', '/tmp/hayai-clone.db', `${targetContainer}:/data/database.db`
-      ]);
-      
-      restoreProcess.on('close', (restoreCode) => {
-        restoreCode === 0 ? resolve() : reject(new Error('Failed to restore database file'));
-      });
-      
-      restoreProcess.on('error', reject);
-    });
-    
-    copyProcess.on('error', reject);
-  });
-}
-
 async function handleClone(options: CloneOptions): Promise<void> {
   const dockerManager = getDockerManager();
   await dockerManager.initialize();
@@ -302,8 +281,8 @@ async function handleClone(options: CloneOptions): Promise<void> {
     process.exit(1);
   }
   
-  // Check if source is running
-  if (sourceInstance.status !== 'running') {
+  // Check if source is running (embedded engines have no server to run)
+  if (sourceInstance.status !== 'running' && sourceInstance.status !== 'embedded') {
     console.error(chalk.red(`❌ Source database '${options.from}' must be running`));
     console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${options.from}`)}`));
     process.exit(1);
@@ -411,16 +390,15 @@ export const cloneCommand = new Command('clone')
   .addHelpText('after', `
 ${chalk.bold('Supported Engines (Fully Compatible):')}
   ${chalk.green('✅ postgresql')}   - Native pg_dump + psql
-  ${chalk.green('✅ mariadb')}      - Native mysqldump + mysql  
+  ${chalk.green('✅ mariadb')}      - Native mysqldump + mysql
   ${chalk.green('✅ redis')}        - Native BGSAVE + RDB copy
-  ${chalk.green('✅ sqlite')}       - Reliable file copy
-  ${chalk.green('✅ duckdb')}       - Reliable file copy
+  ${chalk.green('✅ sqlite, duckdb, leveldb, lmdb')} - Host file copy (embedded)
 
 ${chalk.bold('Unsupported Engines (Manual Clone Required):')}
   ${chalk.red('❌ cassandra, influxdb2, influxdb3, timescaledb, questdb')}
   ${chalk.red('❌ qdrant, weaviate, milvus, arangodb, nebula')}
   ${chalk.red('❌ meilisearch, typesense, victoriametrics, horaedb')}
-  ${chalk.red('❌ leveldb, lmdb, tikv')}
+  ${chalk.red('❌ tikv')}
 
 ${chalk.bold('Examples:')}
   ${chalk.cyan('# Clone PostgreSQL database')}

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -39,10 +39,16 @@ export const listCommand = new Command('list')
         switch (status) {
           case 'running': return chalk.green('●');
           case 'stopped': return chalk.red('●');
+          case 'embedded': return chalk.cyan('●');
           case 'error': return chalk.red('⚠');
           default: return chalk.gray('○');
         }
       };
+
+      const statusColor = (status: string) =>
+        status === 'running' ? chalk.green(status)
+          : status === 'embedded' ? chalk.cyan('embedded (file-based)')
+          : chalk.red(status);
 
       instances.forEach((instance, index) => {
         const template = getTemplate(instance.engine);
@@ -50,8 +56,8 @@ export const listCommand = new Command('list')
         
         console.log(`${index + 1}. ${chalk.bold(instance.name)} ${statusIcon(instance.status)}`);
         console.log(`   Engine: ${chalk.cyan(engineName)}`);
-        console.log(`   Status: ${chalk[instance.status === 'running' ? 'green' : 'red'](instance.status)}`);
-        console.log(`   Port: ${chalk.cyan(instance.port)}`);
+        console.log(`   Status: ${statusColor(instance.status)}`);
+        console.log(`   Port: ${instance.port > 0 ? chalk.cyan(instance.port) : chalk.gray('—')}`);
         console.log(`   URI: ${chalk.gray(instance.connection_uri)}`);
         console.log(`   Created: ${chalk.gray(new Date(instance.created_at).toLocaleDateString())}`);
         console.log('');
@@ -59,12 +65,16 @@ export const listCommand = new Command('list')
 
       const running = instances.filter(i => i.status === 'running').length;
       const stopped = instances.filter(i => i.status === 'stopped').length;
+      const embedded = instances.filter(i => i.status === 'embedded').length;
       const error = instances.filter(i => i.status === 'error').length;
 
       console.log(chalk.bold('Summary:'));
       console.log(`  Total: ${chalk.cyan(instances.length)}`);
       console.log(`  Running: ${chalk.green(running)}`);
       console.log(`  Stopped: ${chalk.red(stopped)}`);
+      if (embedded > 0) {
+        console.log(`  Embedded: ${chalk.cyan(embedded)}`);
+      }
       if (error > 0) {
         console.log(`  Error: ${chalk.red(error)}`);
       }

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -18,6 +18,8 @@ async function createSnapshotDirectory(dir: string): Promise<void> {
   }
 }
 
+const EMBEDDED_ENGINES = new Set(['sqlite', 'duckdb', 'leveldb', 'lmdb']);
+
 async function createSnapshot(
   instance: any,
   snapshotPath: string
@@ -25,6 +27,12 @@ async function createSnapshot(
   const template = getTemplate(instance.engine);
   if (!template) {
     throw new Error(`Template not found for engine: ${instance.engine}`);
+  }
+
+  // Embedded engines are host files — archive the data directory directly
+  if (EMBEDDED_ENGINES.has(instance.engine)) {
+    await createEmbeddedSnapshot(instance.volume, snapshotPath);
+    return;
   }
 
   // Choose appropriate backup method based on database type
@@ -175,6 +183,18 @@ async function createInfluxDBSnapshot(instanceName: string, snapshotPath: string
   });
 }
 
+async function createEmbeddedSnapshot(volumePath: string, snapshotPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tarProcess = spawn('tar', ['-czf', snapshotPath, '-C', volumePath, '.']);
+
+    tarProcess.on('close', (code) => {
+      code === 0 ? resolve() : reject(new Error('Embedded database snapshot failed'));
+    });
+
+    tarProcess.on('error', reject);
+  });
+}
+
 async function createGenericSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const backupProcess = spawn('docker', [
@@ -263,7 +283,7 @@ export const snapshotCommand = new Command('snapshot')
         process.exit(1);
       }
 
-      if (instance.status !== 'running') {
+      if (instance.status !== 'running' && instance.status !== 'embedded') {
         console.error(chalk.red(`❌ Database '${name}' must be running to create snapshot`));
         console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${name}`)}`));
         process.exit(1);
@@ -281,6 +301,7 @@ export const snapshotCommand = new Command('snapshot')
       let extension = 'sql';
       if (instance.engine === 'redis') extension = 'rdb';
       if (instance.engine.includes('influx') || instance.engine === 'cassandra') extension = 'tar.gz';
+      if (EMBEDDED_ENGINES.has(instance.engine)) extension = 'tar.gz';
       if (options.format === 'tar') extension = 'tar.gz';
       
       const snapshotPath = path.join(outputDir, `${snapshotName}.${extension}`);

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -235,15 +235,14 @@ export class DockerManager {
       throw new Error(`Database instance '${name}' already exists`);
     }
 
-    // Get default port for this engine
-    const defaultPort = this.getDefaultPortForEngine(template.engine.name);
-    
-    // Only allocate port for databases that need them (not embedded)
+    // Embedded engines are plain files on the host — no container, no port
+    const isEmbedded = template.engine.ports.length === 0;
+
     let port = 0;
-    if (defaultPort > 0) {
+    if (!isEmbedded && this.getDefaultPortForEngine(template.engine.name) > 0) {
       port = await allocatePort(name, options.port);
     }
-    
+
     // Create data directory
     const dataDir = await getDataDirectory();
     const instanceDataDir = path.join(dataDir, name);
@@ -259,9 +258,9 @@ export class DockerManager {
         ...template.engine.environment,
         ...options.customEnv,
       },
-      status: 'stopped',
+      status: isEmbedded ? 'embedded' : 'stopped',
       created_at: new Date().toISOString(),
-      connection_uri: this.generateConnectionUri(template, port, name),
+      connection_uri: this.generateConnectionUri(template, port, name, instanceDataDir),
     };
 
     // Add to instances
@@ -282,14 +281,16 @@ export class DockerManager {
       throw new Error(`Database instance '${name}' not found`);
     }
 
-    const serviceName = `${name}-db`;
+    if (instance.status !== 'embedded') {
+      const serviceName = `${name}-db`;
 
-    try {
-      // Stop and remove container
-      await this.executeDockerCompose(['stop', serviceName]);
-      await this.executeDockerCompose(['rm', '-f', serviceName]);
-    } catch (error) {
-      console.warn(`Failed to stop/remove container for '${name}':`, error);
+      try {
+        // Stop and remove container
+        await this.executeDockerCompose(['stop', serviceName]);
+        await this.executeDockerCompose(['rm', '-f', serviceName]);
+      } catch (error) {
+        console.warn(`Failed to stop/remove container for '${name}':`, error);
+      }
     }
 
     // Deallocate port if it was allocated
@@ -316,11 +317,16 @@ export class DockerManager {
       throw new Error(`Database instance '${name}' not found`);
     }
 
+    if (instance.status === 'embedded') {
+      console.log(chalk.gray(`ℹ️  '${name}' is an embedded database — nothing to start. Data: ${instance.volume}`));
+      return;
+    }
+
     // Ensure compose file is up to date
     await this.updateComposeFile();
 
     const serviceName = `${name}-db`;
-    
+
     try {
       await this.executeDockerCompose(['up', '-d', serviceName]);
       instance.status = 'running';
@@ -340,11 +346,16 @@ export class DockerManager {
       throw new Error(`Database instance '${name}' not found`);
     }
 
+    if (instance.status === 'embedded') {
+      console.log(chalk.gray(`ℹ️  '${name}' is an embedded database — nothing to stop.`));
+      return;
+    }
+
     // Ensure compose file exists
     await this.updateComposeFile();
 
     const serviceName = `${name}-db`;
-    
+
     try {
       await this.executeDockerCompose(['stop', serviceName]);
       instance.status = 'stopped';
@@ -398,12 +409,14 @@ export class DockerManager {
       
       await this.executeDockerCompose(['up', '-d']);
       for (const [name, instance] of this.instances) {
+        if (instance.status === 'embedded') continue;
         instance.status = 'running';
         this.instances.set(name, instance);
       }
       await this.saveInstances();
     } catch (error) {
       for (const [name, instance] of this.instances) {
+        if (instance.status === 'embedded') continue;
         instance.status = 'error';
         this.instances.set(name, instance);
       }
@@ -419,12 +432,14 @@ export class DockerManager {
       
       await this.executeDockerCompose(['stop']);
       for (const [name, instance] of this.instances) {
+        if (instance.status === 'embedded') continue;
         instance.status = 'stopped';
         this.instances.set(name, instance);
       }
       await this.saveInstances();
     } catch (error) {
       for (const [name, instance] of this.instances) {
+        if (instance.status === 'embedded') continue;
         instance.status = 'error';
         this.instances.set(name, instance);
       }
@@ -466,6 +481,9 @@ export class DockerManager {
 
     // Add services for each database instance
     for (const [name, instance] of this.instances) {
+      if (instance.status === 'embedded') {
+        continue; // embedded engines are host files, not containers
+      }
       const serviceName = `${name}-db`;
       const defaultPort = this.getDefaultPortForEngine(instance.engine);
       
@@ -550,7 +568,7 @@ export class DockerManager {
     }
   }
 
-  private generateConnectionUri(template: DatabaseTemplate, port: number, dbName: string): string {
+  private generateConnectionUri(template: DatabaseTemplate, port: number, dbName: string, volumePath: string): string {
     const engine = template.engine;
     const env = engine.environment;
 
@@ -586,13 +604,16 @@ export class DockerManager {
         return `http://localhost:${port}`;
       
       case 'sqlite':
-        return `sqlite:///${dbName}.db`;
-      
+        return `sqlite://${path.join(volumePath, `${dbName}.db`)}`;
+
       case 'duckdb':
-        return `duckdb:///${dbName}.duckdb`;
-      
+        return `duckdb://${path.join(volumePath, `${dbName}.duckdb`)}`;
+
       case 'leveldb':
-        return `leveldb:///${dbName}`;
+        return `leveldb://${volumePath}`;
+
+      case 'lmdb':
+        return `lmdb://${volumePath}`;
       
       // Time Series Databases
       case 'influxdb3':
@@ -660,6 +681,7 @@ export class DockerManager {
       sqlite: 0, // No port for embedded
       duckdb: 0, // No port for embedded
       leveldb: 0, // No port for embedded
+      lmdb: 0, // No port for embedded
       // Time Series Databases
       influxdb3: 8086,
       influxdb2: 8086,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -64,7 +64,9 @@ export interface DatabaseInstance {
   port: number;
   volume: string;
   environment: Record<string, string>;
-  status: 'running' | 'stopped' | 'error';
+  // 'embedded' marks file-based engines (sqlite, duckdb, ...) that have no
+  // container and therefore no start/stop lifecycle.
+  status: 'running' | 'stopped' | 'error' | 'embedded';
   created_at: string;
   connection_uri: string;
 }


### PR DESCRIPTION
P1 follow-up from the audit: sqlite/duckdb/leveldb/lmdb were composed as `alpine:latest` services with no command — the container exits instantly and restart-loops under `unless-stopped`, while `start` reported success and `clone` tried to docker-cp a file nothing creates out of a container that can't stay up.

## Changes

- New `embedded` instance status: these engines get **no compose service**, `start`/`stop` explain there's no server, bulk operations skip them, and `remove` skips the container teardown.
- Connection URIs now point at the real file path on the host (e.g. `sqlite://<data-dir>/<name>.db`).
- `clone` copies the instance data directory on the host — which also makes **leveldb and lmdb cloneable** for the first time.
- `snapshot` archives the data directory with host `tar` instead of exec'ing into a nonexistent container.
- `list` shows them as `embedded (file-based)` with no port.

## Verification

- build / tests (7/7) / lint — clean