### PR TITLE
fix: redis merge moves data natively; merge wording matches behavior

### DIFF
--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -34,8 +34,7 @@ async function previewMerge(sourceInstance: any, targetInstance: any): Promise<v
   
   console.log(chalk.bold('\nMerge Operation:'));
   console.log(`  ${chalk.green(sourceInstance.name)} data → ${chalk.yellow(targetInstance.name)}`);
-  console.log(`  ${chalk.green(targetInstance.name)} data → ${chalk.yellow(sourceInstance.name)}`);
-  console.log(`  Result: Both databases will contain combined data`);
+  console.log(`  Result: target contains combined data; source is unchanged`);
   
   console.log(chalk.yellow('\n⚠️  Warning:'));
   console.log('  • This operation is irreversible without backups');
@@ -51,7 +50,7 @@ async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise
   const sourceContainer = `${sourceInstance.name}-db`;
   const targetContainer = `${targetInstance.name}-db`;
   
-  console.log(chalk.cyan(`🔄 Merging ${sourceInstance.name} ↔ ${targetInstance.name}...`));
+  console.log(chalk.cyan(`🔄 Merging ${sourceInstance.name} → ${targetInstance.name}...`));
   
   // Check engine compatibility
   if (sourceInstance.engine !== targetInstance.engine) {
@@ -74,7 +73,7 @@ async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise
     }
   }
   
-  console.log(chalk.green(`✅ Successfully merged ${sourceInstance.name} ↔ ${targetInstance.name}`));
+  console.log(chalk.green(`✅ Successfully merged ${sourceInstance.name} → ${targetInstance.name}`));
 }
 
 async function mergePostgreSQL(
@@ -331,7 +330,7 @@ async function handleMerge(options: MergeOptions): Promise<void> {
       {
         type: 'confirm',
         name: 'proceed',
-        message: `⚠️  Merge ${options.source} ↔ ${options.target}? This operation is irreversible!`,
+        message: `⚠️  Merge ${options.source} into ${options.target}? This operation is irreversible!`,
         default: false,
       },
     ]);
@@ -351,7 +350,7 @@ async function handleMerge(options: MergeOptions): Promise<void> {
     spinner.succeed('Database merge completed successfully');
     
     console.log(chalk.green('\n✅ Merge operation completed!'));
-    console.log(chalk.yellow('💡 Both databases now contain the combined data'));
+    console.log(chalk.yellow(`💡 '${options.target}' now contains the combined data; '${options.source}' is unchanged`));
     console.log(chalk.yellow('💡 Commands:'));
     console.log(`  • ${chalk.cyan('hayai list')} - View all databases`);
     console.log(`  • ${chalk.cyan('hayai studio')} - Open admin dashboards`);
@@ -364,7 +363,7 @@ async function handleMerge(options: MergeOptions): Promise<void> {
 }
 
 export const mergeCommand = new Command('merge')
-  .description('Merge two database instances bidirectionally')
+  .description('Merge a source database into a target database')
   .option('-s, --source <name>', 'Source database name')
   .option('-t, --target <name>', 'Target database name')
   .option('--preview', 'Preview the merge operation without executing')
@@ -386,10 +385,9 @@ ${chalk.bold('Examples:')}
   hayai merge -s dbA -t dbB --execute --force
 
 ${chalk.bold('How Merge Works:')}
-  • Data from dbA is copied to dbB
-  • Data from dbB is copied to dbA  
-  • Both databases end up with combined data
-  • Conflicts are resolved automatically when possible
+  • Data from the source is copied into the target
+  • The source database is left unchanged
+  • Conflicts are resolved in favor of the source when possible
 
 ${chalk.bold('Supported Engines:')}
   • PostgreSQL, MariaDB: SQL-level merging

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -150,60 +150,83 @@ async function mergeMariaDB(
 
 async function mergeRedis(sourceContainer: string, targetContainer: string): Promise<void> {
   console.log(chalk.yellow('🔄 Merging Redis databases...'));
-  
+
+  // SCAN instead of KEYS — KEYS blocks the server on large datasets
+  const keys = await scanRedisKeys(sourceContainer);
+  if (keys.length === 0) {
+    return; // Nothing to merge
+  }
+
+  // MIGRATE moves each value container-to-container over the shared compose
+  // network, preserving binary data — piping DUMP output through a text
+  // pipeline corrupts it. COPY keeps the source intact; REPLACE resolves
+  // conflicts in favor of the source.
+  const failed: string[] = [];
+  for (const key of keys) {
+    const ok = await migrateRedisKey(sourceContainer, targetContainer, key);
+    if (!ok) {
+      failed.push(key);
+    }
+  }
+
+  if (failed.length > 0) {
+    throw new Error(
+      `Redis merge failed for ${failed.length}/${keys.length} keys (e.g. '${failed[0]}')`
+    );
+  }
+
+  console.log(chalk.gray(`   ${keys.length} keys merged`));
+}
+
+async function scanRedisKeys(container: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    // Get all keys from source
-    const sourceKeysProcess = spawn('docker', [
-      'exec', sourceContainer, 'redis-cli', 'KEYS', '*'
-    ]);
-    
-    let sourceKeys = '';
-    sourceKeysProcess.stdout.on('data', (data) => {
-      sourceKeys += data.toString();
+    const scanProcess = spawn('docker', ['exec', container, 'redis-cli', '--scan']);
+
+    let output = '';
+    scanProcess.stdout.on('data', (data) => {
+      output += data.toString();
     });
-    
-    sourceKeysProcess.on('close', () => {
-      if (sourceKeys.trim().split('\n').filter(key => key.trim()).length === 0) {
-        resolve(); // No keys to copy
-        return;
+
+    scanProcess.on('close', (code) => {
+      if (code === 0) {
+        resolve(output.split('\n').map(key => key.trim()).filter(Boolean));
+      } else {
+        reject(new Error('Failed to scan source Redis keys'));
       }
-      
-      // Copy keys with REPLACE to handle conflicts
-      Promise.all(sourceKeys.trim().split('\n').filter(key => key.trim()).map(key => copyRedisKey(sourceContainer, targetContainer, key)))
-        .then(() => resolve())
-        .catch(reject);
     });
-    
-    sourceKeysProcess.on('error', reject);
+
+    scanProcess.on('error', reject);
   });
 }
 
-async function copyRedisKey(fromContainer: string, toContainer: string, key: string): Promise<void> {
-  return new Promise((resolve) => {
-    const copyProcess = spawn('docker', [
-      'exec', fromContainer, 'redis-cli', 'DUMP', key
+async function migrateRedisKey(
+  sourceContainer: string,
+  targetContainer: string,
+  key: string
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    // The compose service name doubles as the DNS name on the shared network.
+    const migrateProcess = spawn('docker', [
+      'exec', sourceContainer,
+      'redis-cli', 'MIGRATE', targetContainer, '6379', key, '0', '5000', 'COPY', 'REPLACE'
     ]);
-    
-    let dumpData = '';
-    copyProcess.stdout.on('data', (data) => {
-      dumpData += data.toString();
+
+    // redis-cli exits 0 even when the server replies with an error,
+    // so success must be read from the reply itself.
+    let reply = '';
+    migrateProcess.stdout.on('data', (data) => {
+      reply += data.toString();
     });
-    
-    copyProcess.on('close', () => {
-      if (dumpData.trim()) {
-        // Restore with REPLACE
-        const restoreProcess = spawn('docker', [
-          'exec', toContainer, 'redis-cli', 'RESTORE', key, '0', dumpData.trim(), 'REPLACE'
-        ]);
-        
-        restoreProcess.on('close', () => resolve());
-        restoreProcess.on('error', () => resolve()); // Continue on errors
-      } else {
-        resolve();
-      }
+    migrateProcess.stderr.on('data', (data) => {
+      reply += data.toString();
     });
-    
-    copyProcess.on('error', () => resolve());
+
+    migrateProcess.on('close', () => {
+      const result = reply.trim();
+      resolve(result === 'OK' || result === 'NOKEY');
+    });
+
+    migrateProcess.on('error', reject);
   });
 }
 


### PR DESCRIPTION
Last data-integrity item from the audit's P1 list.

## Changes

1. **Redis merge actually works now** — the old path piped binary `DUMP` output through a text pipeline (corrupts any non-trivial value), listed keys with `KEYS *` (blocks the server), and swallowed every per-key error, reporting success regardless. Keys are now collected with `redis-cli --scan` and transferred with `MIGRATE <target> 6379 <key> 0 5000 COPY REPLACE` over the shared compose network — Redis serializes and restores the value itself, binary-safe. Failures are counted and surfaced; since `redis-cli` exits 0 even on server error replies, success is read from the `OK`/`NOKEY` reply.
2. **Merge wording matches behavior** — preview, prompts, success output, and help all claimed a bidirectional merge ("both databases end up with combined data"), but every implementation copies source → target only. All wording now says source-into-target, source unchanged.

## Verification

- build / tests (7/7) / lint — clean
- Needs a live two-redis smoke test before release: `hayai init` two redis instances, set keys incl. binary values, `merge --execute`, verify with `RANDOMKEY`/`GET`

Independent of #6 (different files).