### PR TITLE
docs: every document now describes what the code actually does

### DIFF
--- a/.hayaidb
+++ b/.hayaidb
@@ -1,217 +1,34 @@
+# Sample .hayaidb — declarative database configuration for hayai
+# Create everything below with:  hayai sync
+# Docs: HAYAIDB.md
 version: "1.0"
-project: haya
-description: "Hayai project multi-database configuration"
-networks:
-  - hayai-network
-volumes:
-  - postgres-data
-  - redis-data
-  - influxdb2-data
+project: hayai-sample
 
 databases:
-  # PostgreSQL Database
+  # PostgreSQL — main relational database
   main-postgres:
     engine: postgresql
     port: 5432
     environment:
-      # Database Configuration
       POSTGRES_DB: hayai_main
       POSTGRES_USER: admin
-      POSTGRES_PASSWORD: secure_password_123
-      POSTGRES_HOST_AUTH_METHOD: md5
-      
-      # Character Set and Locale
-      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=en_US.UTF-8"
-      
-      # Performance Configuration
-      POSTGRES_SHARED_BUFFERS: "256MB"
-      POSTGRES_EFFECTIVE_CACHE_SIZE: "1GB"
-      POSTGRES_WORK_MEM: "4MB"
-      POSTGRES_MAINTENANCE_WORK_MEM: "64MB"
-      
-      # Connection Configuration
-      POSTGRES_MAX_CONNECTIONS: "100"
-      POSTGRES_LISTEN_ADDRESSES: "*"
-      
-      # Logging Configuration
-      POSTGRES_LOG_DESTINATION: "stderr"
-      POSTGRES_LOGGING_COLLECTOR: "on"
-      POSTGRES_LOG_STATEMENT: "all"
-      POSTGRES_LOG_MIN_DURATION_STATEMENT: "1000"
-      
-      # Backup Configuration
-      POSTGRES_ARCHIVE_MODE: "on"
-      POSTGRES_WAL_LEVEL: "replica"
-      
-    volumes:
-      - "postgres-data:/var/lib/postgresql/data"
-      - "./backups/postgres:/backups"
-    networks:
-      - hayai-network
-    memory: "512m"
-    restart: "unless-stopped"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U admin -d hayai_main"]
-      interval: "30s"
-      timeout: "10s"
-      retries: 3
+      POSTGRES_PASSWORD: change_me_dev_only
 
-  # Redis Cache Database
+  # Redis — cache (the official image needs no environment)
   cache-redis:
     engine: redis
     port: 6379
-    environment:
-      # Authentication
-      REDIS_PASSWORD: redis_secure_password_456
-      
-      # Persistence Configuration
-      REDIS_AOF_ENABLED: "yes"
-      REDIS_RDB_ENABLED: "yes"
-      REDIS_SAVE: "900 1 300 10 60 10000"
-      
-      # Memory Management
-      REDIS_MAXMEMORY: "256mb"
-      REDIS_MAXMEMORY_POLICY: "allkeys-lru"
-      REDIS_MAXMEMORY_SAMPLES: "5"
-      
-      # Network Configuration
-      REDIS_BIND: "0.0.0.0"
-      REDIS_PORT: "6379"
-      REDIS_TIMEOUT: "300"
-      REDIS_KEEPALIVE: "60"
-      
-      # Performance Configuration
-      REDIS_DATABASES: "16"
-      REDIS_HASH_MAX_ZIPLIST_ENTRIES: "512"
-      REDIS_HASH_MAX_ZIPLIST_VALUE: "64"
-      REDIS_LIST_MAX_ZIPLIST_SIZE: "-2"
-      REDIS_SET_MAX_INTSET_ENTRIES: "512"
-      REDIS_ZSET_MAX_ZIPLIST_ENTRIES: "128"
-      REDIS_ZSET_MAX_ZIPLIST_VALUE: "64"
-      
-      # Logging Configuration
-      REDIS_LOGLEVEL: "notice"
-      REDIS_LOGFILE: "/var/log/redis/redis-server.log"
-      
-      # Security Configuration
-      REDIS_PROTECTED_MODE: "no"
-      REDIS_RENAME_COMMAND_FLUSHDB: "FLUSHDB_HAYAI_RENAME"
-      REDIS_RENAME_COMMAND_FLUSHALL: "FLUSHALL_HAYAI_RENAME"
-      
-    volumes:
-      - "redis-data:/data"
-      - "./backups/redis:/backups"
-      - "./logs/redis:/var/log/redis"
-    networks:
-      - hayai-network
-    memory: "256m"
-    restart: "unless-stopped"
-    healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping || exit 1"]
-      interval: "30s"
-      timeout: "10s"
-      retries: 3
 
-  # InfluxDB 2.x Time Series Database
+  # InfluxDB 2.x — metrics
   metrics-influxdb2:
     engine: influxdb2
-    port: 8086
     environment:
-      # Database Configuration
-      INFLUXDB_DB: hayai_metrics
-      INFLUXDB_ADMIN_USER: admin
-      INFLUXDB_ADMIN_PASSWORD: influx_secure_password_789
-      INFLUXDB_USER: metrics_user
-      INFLUXDB_USER_PASSWORD: metrics_password_101
-      
-      # Authentication & Security
-      INFLUXDB_HTTP_AUTH_ENABLED: "true"
-      INFLUXDB_HTTP_HTTPS_ENABLED: "false"
-      INFLUXDB_HTTP_FLUX_ENABLED: "true"
-      
-      # Organization & Bucket Configuration
-      DOCKER_INFLUXDB_INIT_MODE: "setup"
-      DOCKER_INFLUXDB_INIT_USERNAME: "admin"
-      DOCKER_INFLUXDB_INIT_PASSWORD: "influx_secure_password_789"
-      DOCKER_INFLUXDB_INIT_ORG: "hayai-org"
-      DOCKER_INFLUXDB_INIT_BUCKET: "hayai-metrics"
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: "hayai-admin-token-super-secret-123456789"
-      
-      # Performance Configuration
-      INFLUXDB_DATA_MAX_SERIES_PER_DATABASE: "1000000"
-      INFLUXDB_DATA_MAX_VALUES_PER_TAG: "100000"
-      INFLUXDB_COORDINATOR_WRITE_TIMEOUT: "10s"
-      INFLUXDB_COORDINATOR_MAX_CONCURRENT_QUERIES: "0"
-      INFLUXDB_COORDINATOR_QUERY_TIMEOUT: "0s"
-      
-      # Retention Policy
-      INFLUXDB_DATA_RETENTION_AUTO_CREATE: "true"
-      INFLUXDB_DATA_RETENTION_CHECK_ENABLED: "true"
-      INFLUXDB_DATA_RETENTION_CHECK_PERIOD: "30m"
-      
-      # HTTP Configuration
-      INFLUXDB_HTTP_BIND_ADDRESS: ":8086"
-      INFLUXDB_HTTP_LOG_ENABLED: "true"
-      INFLUXDB_HTTP_SUPPRESS_WRITE_LOG: "false"
-      INFLUXDB_HTTP_ACCESS_LOG_PATH: "/var/log/influxdb/access.log"
-      
-      # Logging Configuration
-      INFLUXDB_LOGGING_LEVEL: "info"
-      INFLUXDB_LOGGING_FORMAT: "auto"
-      INFLUXDB_LOGGING_SUPPRESS_LOGO: "false"
-      
-      # Storage Configuration
-      INFLUXDB_STORAGE_ENGINE: "tsm1"
-      INFLUXDB_DATA_DIR: "/var/lib/influxdb2"
-      INFLUXDB_DATA_WAL_DIR: "/var/lib/influxdb2/wal"
-      
-      # Engine Configuration
-      INFLUXDB_DATA_CACHE_MAX_MEMORY_SIZE: "1gb"
-      INFLUXDB_DATA_CACHE_SNAPSHOT_MEMORY_SIZE: "25mb"
-      INFLUXDB_DATA_CACHE_SNAPSHOT_WRITE_COLD_DURATION: "10m"
-      INFLUXDB_DATA_COMPACT_FULL_WRITE_COLD_DURATION: "4h"
-      
-    volumes:
-      - "influxdb2-data:/var/lib/influxdb2"
-      - "./backups/influxdb2:/backups"
-      - "./logs/influxdb2:/var/log/influxdb"
-      - "./config/influxdb2:/etc/influxdb2"
-    networks:
-      - hayai-network
-    memory: "512m"
-    restart: "unless-stopped"
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8086/ping || exit 1"]
-      interval: "30s"
-      timeout: "10s"
-      retries: 3
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: change_me_dev_only
+      DOCKER_INFLUXDB_INIT_ORG: hayai-org
+      DOCKER_INFLUXDB_INIT_BUCKET: hayai-metrics
 
-# Global Configuration
-global:
-  # Default network settings
-  network:
-    name: hayai-network
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: "172.20.0.0/16"
-  
-  # Default volume settings
-  volumes:
-    driver: local
-    
-  # Default resource limits
-  resources:
-    default_memory: "256m"
-    default_cpu_limit: "1"
-    
-  # Default restart policy
-  restart_policy: "unless-stopped"
-  
-  # Default logging configuration
-  logging:
-    driver: "json-file"
-    options:
-      max-size: "10m"
-      max-file: "3"
+  # SQLite — embedded, managed as a host file (no port, no container)
+  dev-sqlite:
+    engine: sqlite

--- a/ABOUT_BACKUP.md
+++ b/ABOUT_BACKUP.md
@@ -1,536 +1,113 @@
-# 📸 Backup & Snapshot System - Hayai
+# 📸 Backup & Snapshot System
 
 ## 🎯 Overview
 
-Hayai provides a **comprehensive backup system** designed for developers who need reliable data protection across multiple database types. The system offers **two complementary approaches**: individual database snapshots for quick backups and complete environment backups for full data protection.
+`hayai snapshot` creates per-database backups using each engine's **native
+backup tool**, written to a local directory. Restoring is currently a
+**manual step** (documented below) — a `restore` command is on the roadmap.
 
-## 🔧 Two Backup Systems
-
-### **1. 📸 Individual Snapshots** - `hayai snapshot`
-**Purpose**: Quick backup of specific databases during development
-
-### **2. 🏢 Complete Environment Backup** - Script-based
-**Purpose**: Full environment backup including all databases, logs, and metadata
-
----
-
-## 📸 Individual Snapshots System
-
-### **Basic Usage**
+## 📸 Creating Snapshots
 
 ```bash
-# Create a snapshot of a specific database
+# Snapshot a database (default output: ./snapshots)
 hayai snapshot <database-name>
 
-# Create compressed snapshot with custom output
-hayai snapshot mydb --compress --output ./my-backups
+# Custom output directory
+hayai snapshot mydb --output ./my-backups
 
-# List all available snapshots
+# List existing snapshots
 hayai snapshot list
 
-# Create snapshot in specific format
-hayai snapshot mydb --format tar --compress
+# Remove old snapshots, keeping the most recent 5 per database
+hayai snapshot clean
+hayai snapshot clean --keep 10
 ```
 
-### **Supported Database Engines & Formats**
+Snapshots are named `<name>-snapshot-<timestamp>.<ext>`.
 
-| Database Engine | Default Format | Backup Method | Output Extension |
-|----------------|----------------|---------------|------------------|
-| **PostgreSQL** | SQL | `pg_dump` | `.sql` |
-| **MariaDB** | SQL | `mysqldump` | `.sql` |
-| **Redis** | RDB | `BGSAVE` | `.rdb` |
-| **SQLite** | Database File | Direct Copy | `.db` |
-| **DuckDB** | Database File | Direct Copy | `.db` |
-| **InfluxDB 2.x/3** | Compressed | `tar` Archive | `.tar.gz` |
-| **All Others** | Generic | `tar` Archive | `.tar.gz` |
+### Engines & formats
 
-### **Command Options**
+| Engine | Backup method | Output |
+|--------|---------------|--------|
+| PostgreSQL, TimescaleDB | `pg_dump --clean --create` (instance credentials) | `.sql` |
+| MariaDB | `mysqldump --all-databases` (instance credentials) | `.sql` |
+| Redis | `BGSAVE` + RDB copy | `.rdb` |
+| InfluxDB 2.x | `influx backup` + tar | `.tar.gz` |
+| Cassandra | `nodetool snapshot` + tar | `.tar.gz` |
+| SQLite, DuckDB, LevelDB, LMDB | host-side archive of the data directory | `.tar.gz` |
+| All others | tar of the container's data directory | `.tar.gz` |
+
+Requirements: the database must be **running** (embedded engines are always
+snapshottable since they're plain files).
+
+## ♻️ Restoring (manual for now)
+
+### PostgreSQL / TimescaleDB
 
 ```bash
-hayai snapshot <name> [options]
-
-Options:
-  -o, --output <path>      Output directory for snapshot (default: ./snapshots)
-  -c, --compress           Compress the snapshot
-  --format <format>        Snapshot format: sql, rdb, tar (default: sql)
-  -h, --help              Show help
+# Restore into a running hayai instance (use the instance's credentials)
+docker exec -i <name>-db psql -U admin -d postgres < snapshots/<file>.sql
 ```
 
-### **Snapshot Process Flow**
+The dump was taken with `--clean --create`, so it drops and recreates the
+database it contains.
 
-```mermaid
-graph TD
-    A[hayai snapshot mydb] --> B{Database Running?}
-    B -->|No| C[❌ Error: Database must be running]
-    B -->|Yes| D[Detect Database Engine]
-    D --> E{Engine Type}
-    E -->|PostgreSQL| F[pg_dump → .sql]
-    E -->|Redis| G[BGSAVE → .rdb]
-    E -->|SQLite| H[Copy file → .db]
-    E -->|Others| I[tar archive → .tar.gz]
-    F --> J[Save to snapshots/]
-    G --> J
-    H --> J
-    I --> J
-    J --> K[✅ Snapshot Created]
-```
-
-### **Directory Structure**
-
-```
-project/
-├── snapshots/                                    # Snapshot directory
-│   ├── mydb-snapshot-2025-01-08T10-30-45Z.sql   # PostgreSQL snapshot
-│   ├── cache-snapshot-2025-01-08T10-31-12Z.rdb  # Redis snapshot
-│   ├── data-snapshot-2025-01-08T10-32-01Z.db    # SQLite snapshot
-│   └── influx-snapshot-2025-01-08T10-33-15Z.tar.gz # InfluxDB snapshot
-```
-
-### **Practical Examples**
-
-#### **Development Workflow**
-```bash
-# 1. Create snapshot before risky operations
-hayai snapshot production-db
-
-# 2. Perform development/testing
-# ... make changes ...
-
-# 3. If something goes wrong, restore from snapshot
-# (manual restoration process)
-
-# 4. Create final snapshot after successful changes
-hayai snapshot production-db --compress
-```
-
-#### **Database-Specific Examples**
-
-**PostgreSQL**:
-```bash
-# Create SQL dump
-hayai snapshot user-db
-# → snapshots/user-db-snapshot-2025-01-08T10-30-45Z.sql
-
-# Restore manually:
-docker exec -i hayai-user-db-1 psql -U admin -d database < snapshots/user-db-snapshot-2025-01-08T10-30-45Z.sql
-```
-
-**Redis**:
-```bash
-# Create RDB backup
-hayai snapshot session-cache
-# → snapshots/session-cache-snapshot-2025-01-08T10-31-12Z.rdb
-
-# Restore manually:
-docker cp snapshots/session-cache-snapshot-2025-01-08T10-31-12Z.rdb hayai-session-cache-1:/data/dump.rdb
-docker restart hayai-session-cache-1
-```
-
----
-
-## 🏢 Complete Environment Backup System
-
-### **Script-Based Backup**
-
-The environment backup system uses the `scripts/db-lifecycle.sh` script to create comprehensive backups of the entire Hayai environment.
+### MariaDB
 
 ```bash
-# Create complete environment backup
-./scripts/db-lifecycle.sh backup
-
-# Restore from specific backup
-./scripts/db-lifecycle.sh restore backups/20250108_103045
-
-# List available backups
-ls -la backups/
+docker exec -i -e MYSQL_PWD=<root-password> <name>-db mysql -u root < snapshots/<file>.sql
 ```
 
-### **What's Included in Environment Backup**
-
-- ✅ **All Database Dumps**: PostgreSQL, MariaDB with full schema and data
-- ✅ **Redis Data**: RDB snapshots with all keys and values
-- ✅ **Database-Specific Data**: Users, products, and other table-specific exports
-- ✅ **System Logs**: Application and database logs
-- ✅ **Metadata**: Backup information, timestamps, container details
-- ✅ **Configuration State**: Current database configurations
-
-### **Environment Backup Structure**
-
-```
-backups/20250108_103045/
-├── backup_info.txt              # 📋 Backup metadata
-├── users_backup.sql             # 🐘 Full PostgreSQL dump
-├── users_data.sql               # 👥 Users table data only
-├── products_data.sql            # 📦 Products table data only
-├── redis_backup.rdb             # 🔴 Redis RDB snapshot
-└── logs_backup/                 # 📝 System logs
-    ├── postgresql.log
-    ├── redis.log
-    └── hayai.log
-```
-
-### **Backup Metadata Example**
-
-```txt
-# backup_info.txt
-Backup criado em: Mon Jan  8 10:30:45 -03 2025
-Diretório: backups/20250108_103045
-Versão Docker Compose: 2.34.0-desktop.1
-Containers incluídos: cache-redis-db demo-postgres-db main-postgres-db users-db-db
-Total de bancos: 4
-```
-
-### **Environment Backup Process**
+### Redis
 
 ```bash
-# Step-by-step process
-backup_data() {
-    # 1. Create timestamped directory
-    BACKUP_DIR="backups/$(date +%Y%m%d_%H%M%S)"
-    mkdir -p "$BACKUP_DIR"
-    
-    # 2. Backup PostgreSQL databases
-    docker-compose exec -T users-db-db pg_dump -U admin -d database > "$BACKUP_DIR/users_backup.sql"
-    docker-compose exec -T users-db-db pg_dump -U admin -d database --data-only --table=users > "$BACKUP_DIR/users_data.sql"
-    
-    # 3. Backup Redis
-    docker-compose exec -T cache-redis-db redis-cli BGSAVE
-    docker cp "$(docker-compose ps -q cache-redis-db):/data/dump.rdb" "$BACKUP_DIR/redis_backup.rdb"
-    
-    # 4. Backup logs
-    cp -r logs "$BACKUP_DIR/logs_backup"
-    
-    # 5. Create metadata file
-    echo "Backup criado em: $(date)" > "$BACKUP_DIR/backup_info.txt"
-}
+# Stop the instance, replace the RDB file, start again
+hayai stop <name>
+docker cp snapshots/<file>.rdb <name>-db:/data/dump.rdb
+hayai start <name>
 ```
 
-### **Restoration Process**
+### Embedded engines (SQLite, DuckDB, LevelDB, LMDB)
 
 ```bash
-# Restore complete environment
-./scripts/db-lifecycle.sh restore backups/20250108_103045
-
-# Manual restoration steps:
-# 1. Stop current databases
-docker-compose stop
-
-# 2. Restore PostgreSQL
-docker-compose exec -T users-db-db psql -U admin -d database < backups/20250108_103045/users_backup.sql
-
-# 3. Restore Redis
-docker cp backups/20250108_103045/redis_backup.rdb "$(docker-compose ps -q cache-redis-db):/data/dump.rdb"
-docker-compose restart cache-redis-db
-
-# 4. Restart all services
-docker-compose start
+# The snapshot is a tar of the instance's data directory
+tar -xzf snapshots/<file>.tar.gz -C ./data/<name>/
 ```
 
----
-
-## 🛠️ Configuration-Based Backup (.hayaidb)
-
-### **Volume Mapping for Persistent Backups**
-
-Configure automatic backup directories in your `.hayaidb` file:
-
-```yaml
-version: "1.0"
-project: my-app
-databases:
-  main-postgres:
-    engine: postgresql
-    port: 5432
-    environment:
-      POSTGRES_DB: myapp
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: password
-      # Backup-specific configuration
-      POSTGRES_ARCHIVE_MODE: "on"          # Enable WAL archiving
-      POSTGRES_WAL_LEVEL: "replica"        # Enable replication logs
-    volumes:
-      - "postgres-data:/var/lib/postgresql/data"
-      - "./backups/postgres:/backups"      # 📂 Backup volume
-      - "./archives/postgres:/archives"    # 📂 WAL archive volume
-    memory: "512m"
-    restart: "unless-stopped"
-
-  redis-cache:
-    engine: redis
-    port: 6379
-    environment:
-      REDIS_PASSWORD: password
-      REDIS_AOF_ENABLED: "yes"              # Enable AOF persistence
-      REDIS_RDB_ENABLED: "yes"              # Enable RDB snapshots
-      REDIS_SAVE: "900 1 300 10 60 10000"   # RDB save schedule
-    volumes:
-      - "redis-data:/data"
-      - "./backups/redis:/backups"          # 📂 Backup volume
-    memory: "256m"
-    restart: "unless-stopped"
-```
-
-### **Enterprise Backup Configuration**
-
-```yaml
-# Enterprise-level backup configuration
-global:
-  # Backup configuration
-  backup:
-    enabled: true                    # ✅ Enable automated backups
-    schedule: "0 2 * * *"           # 🕐 Daily at 2 AM
-    retention: "30d"                # 📅 Keep backups for 30 days
-    compression: "gzip"             # 📦 Use gzip compression
-    encryption: true                # 🔒 Encrypt backup files
-
-  # Security configuration
-  security:
-    enable_ssl: true                # 🔐 SSL/TLS encryption
-    ssl_cert_path: "./ssl"          # 📜 SSL certificates path
-    enable_secrets: true            # 🔑 Enable secrets management
-    secrets_backend: "vault"        # 🏦 Use HashiCorp Vault
-```
-
----
-
-## 📋 Best Practices
-
-### **Development Environment**
+### InfluxDB 2.x
 
 ```bash
-# 1. Quick snapshot before risky operations
-hayai snapshot mydb
-
-# 2. Create development backup routine
-#!/bin/bash
-# dev-backup.sh
-for db in $(hayai list --format json | jq -r '.[].name'); do
-    hayai snapshot "$db" --compress
-done
+docker cp snapshots/<file>.tar.gz <name>-db:/tmp/
+docker exec <name>-db sh -c 'cd /tmp && tar -xzf <file>.tar.gz && influx restore /tmp/backup'
 ```
 
-### **Production Environment**
+## 🤖 Automation
+
+Schedule snapshots with cron using the real commands:
 
 ```bash
-# 1. Complete environment backup
-./scripts/db-lifecycle.sh backup
+# Nightly snapshot of one database at 02:00
+0 2 * * * cd /path/to/project && hayai snapshot mydb
 
-# 2. Automated backup script
-#!/bin/bash
-# production-backup.sh
-BACKUP_DIR="/secure/backups/$(date +%Y%m%d_%H%M%S)"
-mkdir -p "$BACKUP_DIR"
+# Snapshot every database (requires jq)
+0 2 * * * cd /path/to/project && hayai list --format json | jq -r '.[].name' | xargs -I{} hayai snapshot {}
 
-# Full environment backup
-./scripts/db-lifecycle.sh backup
-
-# Copy to secure location
-cp -r backups/latest/* "$BACKUP_DIR/"
-
-# Clean old backups (keep last 7 days)
-find /secure/backups -type d -mtime +7 -exec rm -rf {} \;
+# Weekly cleanup, keep last 10 per database
+0 3 * * 0 cd /path/to/project && hayai snapshot clean --keep 10
 ```
 
-### **Backup Strategy Recommendations**
+## 💡 Tips
 
-#### **🔄 Frequency Guidelines**
+- Snapshot before destructive operations (`merge --execute`, `remove`,
+  experimental schema changes).
+- Add `snapshots/` to `.gitignore` (hayai's default `.gitignore` already
+  does) — dumps can be large and may contain data you don't want in git.
+- For full-environment portability, combine `hayai export` (the `.hayaidb`
+  file recreates the *instances*) with snapshots (which carry the *data*).
 
-| Environment | Frequency | Method | Retention |
-|-------------|-----------|--------|-----------|
-| **Development** | Before major changes | `hayai snapshot` | 3-7 days |
-| **Staging** | Daily | Environment backup | 14 days |
-| **Production** | Daily + hourly snapshots | Both methods | 30+ days |
+## 🗺️ Roadmap
 
-#### **📦 Storage Strategy**
+- `hayai snapshot restore <file>` — one-command restore per engine
+- Optional compression flag once it compresses for real
 
-```bash
-# Local development
-snapshots/                    # Quick snapshots
-backups/                     # Environment backups
-
-# Production
-/var/backups/hayai/
-├── daily/                   # Daily full backups
-├── hourly/                  # Hourly snapshots
-└── archived/               # Long-term storage
-```
-
-### **Automation Examples**
-
-#### **Cron Job Setup**
-
-```bash
-# Add to crontab: crontab -e
-
-# Daily full backup at 2 AM
-0 2 * * * cd /path/to/hayai && ./scripts/db-lifecycle.sh backup
-
-# Hourly snapshots during business hours
-0 9-17 * * 1-5 cd /path/to/hayai && hayai snapshot production-db --compress
-
-# Weekly cleanup
-0 3 * * 0 find /path/to/hayai/snapshots -name "*.sql" -mtime +7 -delete
-```
-
-#### **Backup Health Check**
-
-```bash
-#!/bin/bash
-# backup-health-check.sh
-
-# Check if recent backups exist
-LATEST_BACKUP=$(find backups/ -name "backup_info.txt" -mtime -1 | head -1)
-if [ -z "$LATEST_BACKUP" ]; then
-    echo "❌ No recent backup found!"
-    exit 1
-fi
-
-# Check backup integrity
-BACKUP_DIR=$(dirname "$LATEST_BACKUP")
-if [ ! -f "$BACKUP_DIR/users_backup.sql" ]; then
-    echo "❌ Incomplete backup: missing users_backup.sql"
-    exit 1
-fi
-
-echo "✅ Backup health check passed"
-```
-
----
-
-## 🚨 Troubleshooting
-
-### **Common Issues**
-
-#### **Issue**: Snapshot fails with "Database not running"
-```bash
-# Solution: Start the database first
-hayai start mydb
-hayai snapshot mydb
-```
-
-#### **Issue**: Permission denied during backup
-```bash
-# Check Docker permissions
-docker-compose exec users-db-db whoami
-docker-compose exec users-db-db ls -la /tmp
-
-# Fix permissions
-docker-compose exec users-db-db chown postgres:postgres /tmp
-```
-
-#### **Issue**: Snapshot directory doesn't exist
-```bash
-# Create directory manually
-mkdir -p snapshots
-chmod 755 snapshots
-
-# Or let Hayai create it
-hayai snapshot mydb  # Will create directory automatically
-```
-
-#### **Issue**: Large database timeout
-```bash
-# Increase timeout for large databases
-hayai snapshot large-db --format tar --compress
-# TAR format is more efficient for large datasets
-```
-
-### **Backup Verification**
-
-```bash
-# Verify PostgreSQL backup
-psql -U admin -d test_restore < snapshots/mydb-snapshot-latest.sql
-
-# Verify Redis backup
-redis-cli --rdb snapshots/cache-snapshot-latest.rdb
-
-# Check backup file integrity
-file snapshots/*.sql    # Should show "ASCII text"
-file snapshots/*.rdb    # Should show "Redis RDB"
-```
-
----
-
-## 🔗 Related Commands
-
-### **Complete Command Reference**
-
-```bash
-# Snapshot commands
-hayai snapshot <name>                    # Create snapshot
-hayai snapshot <name> --compress         # Create compressed snapshot
-hayai snapshot <name> --format tar       # Create TAR archive
-hayai snapshot <name> -o /custom/path    # Custom output directory
-hayai snapshot list                      # List all snapshots
-hayai snapshot list -d /custom/snapshots # List from custom directory
-
-# Environment backup commands
-./scripts/db-lifecycle.sh backup         # Create environment backup
-./scripts/db-lifecycle.sh restore <dir>  # Restore environment backup
-./scripts/db-lifecycle.sh status         # Show backup status
-
-# Configuration commands
-hayai init --config .hayaidb             # Initialize with backup config
-hayai validate --config .hayaidb         # Validate backup configuration
-```
-
-### **Integration with Other Hayai Commands**
-
-```bash
-# Backup before operations
-hayai snapshot mydb && hayai remove mydb   # Backup before removal
-hayai snapshot mydb && hayai init -n mydb-new -e postgresql  # Backup before migration
-
-# Backup all running databases
-hayai list --running | xargs -I {} hayai snapshot {}
-```
-
----
-
-## 💡 Tips & Tricks
-
-### **Development Workflow Tips**
-
-```bash
-# Create alias for quick backup
-alias hbackup='hayai snapshot'
-alias hrestore='echo "Manual restore required - check ABOUT_BACKUP.md"'
-
-# Quick backup all
-alias hbackup-all='for db in $(hayai list --format json | jq -r ".[].name"); do hayai snapshot "$db"; done'
-```
-
-### **Monitoring Backup Size**
-
-```bash
-# Check snapshot sizes
-du -sh snapshots/*
-find snapshots -name "*.sql" -exec du -sh {} \; | sort -hr
-
-# Monitor backup growth
-watch -n 60 'du -sh snapshots/ backups/'
-```
-
-### **Backup Compression Comparison**
-
-| Format | Size | Speed | Compatibility |
-|--------|------|-------|--------------|
-| **SQL** | Large | Fast | ✅ Standard |
-| **SQL + gzip** | Small | Medium | ✅ Universal |
-| **TAR** | Medium | Medium | ✅ Archive |
-| **TAR + gzip** | Small | Slow | ✅ Compressed |
-
----
-
-## 📚 See Also
-
-- **[README.md](README.md)** - Main project documentation
-- **[HAYAIDB.md](HAYAIDB.md)** - Configuration file documentation
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
-- **[DEVELOPMENT.md](DEVELOPMENT.md)** - Development setup
-
----
-
-**📸 Backup is not just a feature - it's your safety net for confident development!**
-
-*Making database management 速い (hayai) since 2025* 
+See [SECURITY.md](SECURITY.md) for how credentials are handled during backups.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,39 @@
-# Contributing to Hayai v0.4.1
+# Contributing to Hayai
 
 Welcome to Hayai! We're building the fastest way to manage local databases with Docker.
 
-## 📦 Database Categories (v0.4.1)
+## 📦 Database Categories
 
-Hayai uses **8 technical categories** based on query interface, not deployment method:
-
-- **SQL (4):** postgresql, mariadb, sqlite, duckdb
-- **Embedded (1):** leveldb  
-- **Key-Value (1):** redis
-- **Wide Column (1):** cassandra
-- **Vector (3):** qdrant, weaviate, milvus
-- **Graph (1):** arangodb
-- **Search (2):** meilisearch, typesense
-- **Time Series (6):** influxdb2, influxdb3, timescaledb, questdb, victoriametrics, horaedb
+Hayai categorizes engines by **query interface** (SQL, graph, vector, ...), not
+deployment method. The authoritative list lives in `src/core/templates.ts` —
+run `hayai init` or check the README for the current set, rather than trusting
+any hardcoded list in docs.
 
 ### Adding New Database Support
 
 When adding a new database:
 1. Categorize by **query interface** (SQL, Graph, etc.) not deployment
 2. Update `src/core/templates.ts` with the new template
-3. Update `src/core/types.ts` if new category needed
+3. Update `src/core/types.ts` if a new category is needed
 4. Update README.md and CLI help text
 5. Add tests for the new database template
+6. Only declare an `admin_dashboard` if the database container itself serves a
+   web UI — hayai does not create separate dashboard containers
+
+## Workflow
+
+We use a pull-request flow on short-lived branches:
+
+1. Branch from `master` using a conventional prefix: `feat/...`, `fix/...`,
+   `docs/...`, `chore/...`
+2. Keep each commit single-concern with a conventional message (see below)
+3. Open a PR; CI must pass (lint, build, tests)
+4. A `feat:` change should come with a test proving the feature does something
+5. Branches are deleted after merge
 
 ## Commit Message Guidelines
 
-We follow [Conventional Commits](https://www.conventionalcommits.org/) specification.
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
 
 ### Format
 
@@ -74,6 +81,8 @@ revert: revert commit abc123
 4. Keep the subject line under 50 characters
 5. Use the body to explain what and why vs. how
 6. Separate subject from body with a blank line
+7. The type must be truthful: a `feat:` commit delivers a working feature,
+   not a placeholder or simulation
 
 ### Scopes (optional)
 
@@ -93,10 +102,13 @@ docs(readme): update installation section
 4. Run tests: `npm test`
 5. Check linting: `npm run lint`
 
+See [DEVELOPMENT.md](DEVELOPMENT.md) for the full environment guide.
+
 ## Pull Request Process
 
 1. Follow the commit message guidelines
-2. Update documentation if needed
+2. Update documentation if behavior changes — docs must describe what the
+   code actually does
 3. Add tests for new features
 4. Ensure all tests pass
 5. Update the README.md if needed
@@ -107,4 +119,4 @@ docs(readme): update installation section
 - Follow ESLint configuration
 - Use Prettier for code formatting
 - Write meaningful variable and function names
-- Add JSDoc comments for public APIs 
+- Add JSDoc comments for public APIs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,57 +1,30 @@
 # Development Setup Guide
 
-## 🚀 Hayai v0.4.1 - Development Environment
-
 Before you start working on Hayai, make sure you have the following installed:
 
 - **Node.js** (v18 or higher)
-- **npm** or **yarn**
-- **Docker** (for testing database containers)
+- **npm**
+- **Docker** with the Compose V2 plugin (for testing database containers)
 - **Git**
 
-## 📦 Current Database Support (v0.4.1)
-
-Hayai supports **19 databases across 8 technical categories**:
-
-- **SQL (4):** postgresql, mariadb, sqlite, duckdb
-- **Embedded (1):** leveldb  
-- **Key-Value (1):** redis
-- **Wide Column (1):** cassandra
-- **Vector (3):** qdrant, weaviate, milvus
-- **Graph (1):** arangodb
-- **Search (2):** meilisearch, typesense
-- **Time Series (6):** influxdb2, influxdb3, timescaledb, questdb, victoriametrics, horaedb
+The supported database list lives in `src/core/templates.ts` — that file is
+the source of truth, not this document.
 
 ## Installation
 
-### Option 1: Using WSL (Recommended for Windows users)
+```bash
+git clone https://github.com/hitoshyamamoto/hayai.git
+cd hayai
+npm install
+```
 
-1. Open WSL terminal
-2. Navigate to your project directory:
-   ```bash
-   cd /home/hitoshi/Documents/github/hitoshyamamoto/hayai
-   ```
-3. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-### Option 2: Using Windows PowerShell
-
-1. Install Node.js for Windows from [nodejs.org](https://nodejs.org/)
-2. Open PowerShell in your project directory
-3. Install dependencies:
-   ```powershell
-   npm install
-   ```
+On Windows, WSL2 is recommended (Docker Desktop integrates with it directly),
+but PowerShell with Node.js for Windows works too.
 
 ## Development Commands
 
 ```bash
-# Install dependencies
-npm install
-
-# Start development mode with hot reload
+# Build and run the CLI once
 npm run dev
 
 # Build the project
@@ -60,16 +33,12 @@ npm run build
 # Run tests
 npm test
 
-# Format code
-npm run format
-
-# Lint code
+# Lint code (and auto-fix)
 npm run lint
+npm run lint:fix
 ```
 
 ## Testing Your CLI
-
-After installation, you can test your CLI in development mode:
 
 ```bash
 # Run the CLI in development mode
@@ -89,69 +58,56 @@ npm run dev -- stop
 ```
 hayai/
 ├── src/
-│   ├── cli/                 # CLI interface
-│   │   ├── index.ts         # Main CLI entry point
-│   │   └── commands/        # Command implementations
-│   │       ├── init.ts      # Database initialization
-│   │       ├── start.ts     # Start containers
-│   │       ├── stop.ts      # Stop containers
-│   │       ├── list.ts      # List instances
-│   │       ├── remove.ts    # Remove instances
-│   │       ├── logs.ts      # Show logs
-│   │       ├── studio.ts    # Admin dashboard
-│   │       └── snapshot.ts  # Create snapshots
-│   ├── core/                # Core engine logic
-│   │   ├── types.ts         # Type definitions
-│   │   ├── config.ts        # Configuration management
-│   │   ├── docker.ts        # Docker integration
-│   │   ├── port-manager.ts  # Port allocation
-│   │   └── templates.ts     # Template generation
-│   ├── templates/           # Database templates
-│   ├── api/                 # Optional REST API
-│   └── dashboard/           # Optional web dashboard
-├── dist/                    # Compiled output
-├── package.json             # Dependencies and scripts
-├── tsconfig.json            # TypeScript configuration
-├── hayai.config.yaml         # Global configuration
-└── .gitignore               # Git ignore rules
+│   ├── cli/                  # CLI interface
+│   │   ├── index.ts          # Main CLI entry point
+│   │   └── commands/         # One file per command:
+│   │                         #   init, start, stop, list, remove, logs,
+│   │                         #   studio, snapshot, clone, merge, migrate,
+│   │                         #   export, sync, security
+│   ├── core/                 # Core engine logic
+│   │   ├── types.ts          # Type definitions
+│   │   ├── config.ts         # hayai.config.yaml management
+│   │   ├── docker.ts         # Docker / Compose integration
+│   │   ├── credentials.ts    # Credentials for exec'd db tooling
+│   │   ├── port-manager.ts   # Port allocation
+│   │   ├── templates.ts      # Database engine templates (source of truth)
+│   │   ├── hayaidb.ts        # .hayaidb export/sync
+│   │   └── security.ts       # Standalone security utilities
+│   └── tests/                # Jest tests
+├── dist/                     # Compiled output
+├── package.json              # Dependencies and scripts
+├── tsconfig.json             # TypeScript configuration
+└── hayai.config.yaml         # Global configuration
 ```
 
-## Next Steps
+## How Things Work
 
-1. **Install dependencies** using one of the methods above
-2. **Implement Docker integration** in `src/core/docker.ts`
-3. **Create database templates** in `src/templates/`
-4. **Test with real databases** using Docker
-5. **Add more database engines** to the supported list
-6. **Implement admin dashboard** features
-7. **Add comprehensive tests**
+- Hayai writes a `docker-compose.yml` in the working directory and drives it
+  with `docker compose` (V2). Each instance becomes a `<name>-db` service.
+- Embedded engines (sqlite, duckdb, leveldb, lmdb) get **no container** —
+  they are plain files under `./data/<name>/` with status `embedded`.
+- Instance state is persisted in `./data/instances.json`; port allocations in
+  `./data/port-allocations.json`.
+- Database tooling (pg_dump, mysqldump, redis-cli, ...) runs via `docker exec`
+  using each instance's own environment credentials
+  (see `src/core/credentials.ts`).
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests for new functionality
-5. Submit a pull request
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the branch/commit/PR workflow.
 
 ## Troubleshooting
 
-### WSL Path Issues
-If you encounter path issues with WSL, make sure you're working in the correct directory:
-```bash
-pwd  # Should show /home/hitoshi/Documents/github/hitoshyamamoto/hayai
-```
-
-### Node.js Not Found
-If Node.js is not found, install it:
-- **WSL**: `sudo apt update && sudo apt install nodejs npm`
-- **Windows**: Download from [nodejs.org](https://nodejs.org/)
-
 ### Docker Issues
-Make sure Docker is running:
+Make sure Docker and Compose V2 are available:
 ```bash
 docker --version
+docker compose version
 docker ps
 ```
 
-Ready to build the future of local database management! 🚀 
+### Node.js Not Found
+- **WSL/Linux**: `sudo apt update && sudo apt install nodejs npm`
+- **Windows**: Download from [nodejs.org](https://nodejs.org/)
+
+Ready to build the future of local database management! 🚀

--- a/HAYAIDB.md
+++ b/HAYAIDB.md
@@ -2,944 +2,167 @@
 
 ## 🎯 Overview
 
-The `.hayaidb` file is a **declarative configuration file** that allows you to define multiple databases with their specific parameters in a single location. This approach simplifies database management by providing a centralized configuration system for your development environment.
+The `.hayaidb` file is a **declarative configuration file** that defines your
+project's databases in one place. It works with two commands:
+
+- `hayai export` — writes a `.hayaidb` file describing your current instances
+- `hayai sync` — creates any databases declared in the file that don't exist yet
+
+This makes environments reproducible: commit the file, and a teammate runs
+`hayai sync` to get the same databases.
 
 ## 🚀 Why Use .hayaidb?
 
-### ✅ **Advantages**
 - **🔧 Centralized Configuration**: Define all your databases in one place
-- **📋 Declarative Approach**: Specify what you want, not how to achieve it
 - **🔄 Reproducible Environments**: Share configurations across team members
-- **⚡ Batch Operations**: Initialize, start, or stop multiple databases at once
 - **📝 Version Control**: Track configuration changes in your repository
-- **🛠️ Environment Consistency**: Ensure same setup across different machines
-
-### 🎯 **Use Cases**
-- **Multi-Database Projects**: Applications using different database types
-- **Microservices Architecture**: Each service with its own database
-- **Development Teams**: Standardize database configurations
-- **CI/CD Pipelines**: Automated testing with predefined databases
-- **Learning & Experimentation**: Quick setup for trying different databases
+- **⚡ Batch Creation**: `hayai sync` creates everything that's missing in one run
 
 ## 📁 File Structure
 
-The `.hayaidb` file uses **YAML format** with the following structure:
+The `.hayaidb` file uses **YAML format**:
 
 ```yaml
-version: "1.0"           # Configuration version
-project: <project-name>   # Project identifier
-databases:               # Database definitions
-  <database-name>:       # Unique database identifier
-    engine: <engine>     # Database engine type
-    environment:         # Environment variables
+version: "1.0"            # Required
+project: my-app           # Optional project identifier
+
+databases:
+  <database-name>:        # Unique instance name
+    engine: <engine>      # Required — see supported engines below
+    port: <port>          # Optional — auto-allocated (5000-6000) if omitted
+    environment:          # Optional — passed to the container
       KEY: value
-    port: <port>         # Port number
-    # Additional optional parameters
-    volumes:            # Volume mappings
-      - source:target
-    networks:           # Network configurations
-      - network-name
-    memory: <limit>     # Memory limit
-    restart: <policy>   # Restart policy
 ```
 
-## 🛠️ Configuration Parameters
+### Honored fields
 
-### **Core Parameters**
+| Field | Required | Effect |
+|-------|----------|--------|
+| `version` | ✅ | Must be present; format version |
+| `project` | ❌ | Informational |
+| `databases.<name>.engine` | ✅ | Must be a supported engine |
+| `databases.<name>.port` | ❌ | Preferred host port (1–65535); auto-allocated if omitted or taken |
+| `databases.<name>.environment` | ❌ | Environment variables for the container (credentials, db name, ...) |
 
-| Parameter | Description | Required | Example |
-|-----------|-------------|----------|---------|
-| `version` | Configuration file version | ✅ | `"1.0"` |
-| `project` | Project name/identifier | ✅ | `"my-app"` |
-| `databases` | Database definitions | ✅ | `{}` |
+### Fields that are parsed but **not applied yet**
 
-### **Database Parameters**
+These may appear in the file (and in exported files from other tools) without
+causing errors, but hayai currently ignores them when creating databases:
 
-| Parameter | Description | Required | Example |
-|-----------|-------------|----------|---------|
-| `engine` | Database engine type | ✅ | `postgresql`, `redis`, `influxdb2` |
-| `environment` | Environment variables | ✅ | `POSTGRES_DB: mydb` |
-| `port` | Port number | ✅ | `5432` |
-| `volumes` | Volume mappings | ❌ | `["./data:/var/lib/postgresql/data"]` |
-| `networks` | Network configurations | ❌ | `["backend-network"]` |
-| `memory` | Memory limit | ❌ | `"512m"` |
-| `restart` | Restart policy | ❌ | `"unless-stopped"` |
+- `volumes`, `healthcheck` overrides per database
+- `memory`, `networks`, `restart` per database
+- `profiles` (parsed and displayed by `hayai sync --dry-run`, but not yet
+  usable to select subsets)
+
+Only set `engine`, `port`, and `environment` and you'll get exactly what's
+written.
 
 ## 🗄️ Supported Database Engines
 
-### **SQL Databases**
-- `postgresql` - PostgreSQL database
-- `mariadb` - MariaDB database
+The authoritative list lives in `src/core/templates.ts` and in
+`hayai init` (interactive mode shows every engine). Currently 22 engines:
 
-### **Analytics Databases**
-- `duckdb` - DuckDB analytics database
+- **SQL:** `postgresql`, `mariadb`
+- **Analytics:** `duckdb`
+- **Embedded:** `sqlite`, `lmdb`
+- **Key-Value:** `redis`, `leveldb`, `tikv`
+- **Wide Column:** `cassandra`
+- **Vector:** `qdrant`, `weaviate`, `milvus`
+- **Graph:** `arangodb`, `nebula`
+- **Search:** `meilisearch`, `typesense`
+- **Time Series:** `influxdb2`, `influxdb3`, `timescaledb`, `questdb`, `victoriametrics`, `horaedb`
 
-### **Embedded Databases**
-- `sqlite` - SQLite database
-- `lmdb` - LMDB memory-mapped key-value store
+Embedded engines (`sqlite`, `duckdb`, `leveldb`, `lmdb`) are created as plain
+host files under `./data/<name>/` — they need no `port` or `environment`.
 
-### **Key-Value Databases**
-- `redis` - Redis key-value store
-- `leveldb` - LevelDB key-value store
-- `tikv` - TiKV distributed key-value store
+## 🔧 Commands
 
-### **Wide Column Databases**
-- `cassandra` - Apache Cassandra
-
-### **Graph Databases**
-- `arangodb` - ArangoDB multi-model
-- `nebula` - NebulaGraph distributed graph database
-
-### **Time Series**
-- `influxdb2` - InfluxDB 2.x
-- `influxdb3` - InfluxDB 3 Core
-- `timescaledb` - TimescaleDB
-- `questdb` - QuestDB
-- `victoriametrics` - VictoriaMetrics
-- `horaedb` - Apache HoraeDB
-
-### **Vector & Search**
-- `qdrant` - Qdrant vector database
-- `weaviate` - Weaviate vector database
-- `milvus` - Milvus vector database
-- `meilisearch` - Meilisearch
-- `typesense` - Typesense
-
-## 🔧 Commands Integration
-
-### **Initialize from .hayaidb**
 ```bash
-# Initialize all databases from .hayaidb
-hayai init --config .hayaidb
+# Export current databases to .hayaidb
+hayai export
+hayai export -o my-config.yaml
 
-# Initialize specific database
-hayai init --config .hayaidb --database demo-postgres
+# Preview what sync would create
+hayai sync --dry-run
+
+# Create everything declared in .hayaidb (existing instances are skipped)
+hayai sync
+hayai sync -c my-config.yaml
+
+# Then manage as usual
+hayai start
+hayai list
 ```
 
-### **Batch Operations**
-```bash
-# Start all databases defined in .hayaidb
-hayai start --config .hayaidb
+`hayai sync` is **additive and idempotent**: it never modifies or removes
+existing instances; it only creates missing ones and reports
+created/skipped/errored names.
 
-# Stop all databases
-hayai stop --config .hayaidb
+## 📚 Examples
 
-# List databases from config
-hayai list --config .hayaidb
-```
+### Typical web app stack
 
-### **Configuration Validation**
-```bash
-# Validate .hayaidb configuration
-hayai validate --config .hayaidb
-
-# Check configuration syntax
-hayai config check
-```
-
-## 📝 Environment Variables Guide
-
-### **Common Environment Variables**
-
-#### **PostgreSQL**
 ```yaml
-environment:
-  POSTGRES_DB: database_name          # Database name
-  POSTGRES_USER: username             # Database user
-  POSTGRES_PASSWORD: password         # Database password
-  POSTGRES_HOST_AUTH_METHOD: trust    # Authentication method
-  POSTGRES_INITDB_ARGS: "--encoding=UTF-8"  # Init arguments
-```
-
-#### **Redis**
-```yaml
-environment:
-  REDIS_PASSWORD: password            # Redis password
-  REDIS_AOF_ENABLED: "yes"            # Enable AOF persistence
-  REDIS_RDB_ENABLED: "yes"            # Enable RDB persistence
-  REDIS_MAXMEMORY: "256mb"            # Memory limit
-  REDIS_MAXMEMORY_POLICY: "allkeys-lru"  # Eviction policy
-```
-
-#### **InfluxDB 2.x**
-```yaml
-environment:
-  INFLUXDB_DB: database_name          # Database name
-  INFLUXDB_ADMIN_USER: admin          # Admin username
-  INFLUXDB_ADMIN_PASSWORD: password   # Admin password
-  INFLUXDB_USER: user                 # Regular user
-  INFLUXDB_USER_PASSWORD: password    # User password
-  INFLUXDB_HTTP_AUTH_ENABLED: "true"  # Enable HTTP auth
-```
-
-## 🔄 Migration from Manual Setup
-
-### **Before (Manual Setup)**
-```bash
-hayai init -n postgres -e postgresql -p 5432
-hayai init -n redis -e redis -p 6379
-hayai init -n influx -e influxdb2 -p 8086
-```
-
-### **After (Declarative Setup)**
-```yaml
-# .hayaidb
 version: "1.0"
 project: my-app
+
 databases:
-  postgres:
+  main-postgres:
     engine: postgresql
     port: 5432
     environment:
       POSTGRES_DB: myapp
       POSTGRES_USER: admin
-      POSTGRES_PASSWORD: password
-  redis:
+      POSTGRES_PASSWORD: change_me_dev_only
+
+  cache-redis:
     engine: redis
     port: 6379
-    environment:
-      REDIS_PASSWORD: password
-  influx:
-    engine: influxdb2
-    port: 8086
-    environment:
-      INFLUXDB_DB: myapp
-      INFLUXDB_ADMIN_USER: admin
-      INFLUXDB_ADMIN_PASSWORD: password
-```
 
-```bash
-# Single command replaces all manual setup
-hayai init --config .hayaidb
-```
-
-## 🚀 Best Practices
-
-### **1. Naming Conventions**
-```yaml
-databases:
-  # Good: descriptive names
-  user-service-postgres:
-    engine: postgresql
-  
-  session-cache-redis:
-    engine: redis
-  
-  # Avoid: generic names
-  db1:
-    engine: postgresql
-```
-
-### **2. Environment Organization**
-```yaml
-# Separate environments
-databases:
-  # Development
-  dev-postgres:
-    engine: postgresql
-    environment:
-      POSTGRES_DB: myapp_dev
-  
-  # Testing
-  test-postgres:
-    engine: postgresql
-    environment:
-      POSTGRES_DB: myapp_test
-```
-
-### **3. Security Considerations**
-```yaml
-# Use environment variables for secrets
-environment:
-  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-defaultpassword}
-  REDIS_PASSWORD: ${REDIS_PASSWORD:-defaultpassword}
-```
-
-### **4. Resource Management**
-```yaml
-databases:
-  heavy-database:
-    engine: postgresql
-    memory: "1g"              # Limit memory usage
-    restart: "unless-stopped" # Auto-restart policy
-```
-
-## 🐛 Troubleshooting
-
-### **Common Issues**
-
-#### **Port Conflicts**
-```yaml
-# Error: Port already in use
-databases:
-  postgres:
-    port: 5432  # Already used by system PostgreSQL
-    
-# Solution: Use different port
-databases:
-  postgres:
-    port: 5433  # Use alternative port
-```
-
-#### **Invalid Engine Names**
-```yaml
-# Error: Unknown engine
-databases:
-  mydb:
-    engine: mysql  # Not supported
-    
-# Solution: Use supported engine
-databases:
-  mydb:
-    engine: mariadb  # Supported alternative
-```
-
-#### **Missing Required Environment Variables**
-```yaml
-# Error: Missing required environment variables
-databases:
-  postgres:
-    engine: postgresql
-    # Missing: POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
-    
-# Solution: Add required variables
-databases:
-  postgres:
-    engine: postgresql
-    environment:
-      POSTGRES_DB: mydb
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: password
-```
-
-## 📚 Examples
-
-For complete examples and advanced configurations, see:
-- [Complete .hayaidb example](/.hayaidb)
-- [Development setup examples](/examples/development.hayaidb)
-- [Microservices examples](/examples/microservices.hayaidb)
-- [CI/CD examples](/examples/ci-cd.hayaidb)
-
-## 🎯 Real-World Use Cases
-
-### **Case 1: Simple Web Application** 
-*Complexity Level: 🟢 Beginner*
-
-Perfect for a simple web application with basic database needs.
-
-```yaml
-version: "1.0"
-project: simple-blog
-description: "Basic blog application with PostgreSQL"
-
-databases:
-  blog-database:
-    engine: postgresql
-    port: 5432
-    environment:
-      POSTGRES_DB: blog
-      POSTGRES_USER: blogger
-      POSTGRES_PASSWORD: myblog123
-    memory: "256m"
-    restart: "unless-stopped"
-```
-
-**What this provides:**
-- ✅ Single PostgreSQL database
-- ✅ Basic authentication
-- ✅ Memory limit for resource control
-- ✅ Auto-restart on failure
-
-**Usage:**
-```bash
-# Initialize the blog database
-hayai init --config .hayaidb
-
-# Start the database
-hayai start --config .hayaidb
-
-# Connect to database
-psql -h localhost -p 5432 -U blogger -d blog
-```
-
-**Perfect for:**
-- Learning SQL and database basics
-- Simple CRUD applications
-- Personal projects and prototypes
-- Single-developer projects
-
----
-
-### **Case 2: E-commerce Microservices Platform**
-*Complexity Level: 🟡 Intermediate*
-
-Complex e-commerce platform with multiple specialized databases for different services.
-
-```yaml
-version: "1.0"
-project: ecommerce-platform
-description: "Multi-service e-commerce platform"
-
-networks:
-  - frontend-network
-  - backend-network
-  - cache-network
-
-volumes:
-  - user-data
-  - product-data
-  - order-data
-  - search-data
-  - cache-data
-  - analytics-data
-
-databases:
-  # User Management Service
-  user-service-db:
-    engine: postgresql
-    port: 5432
-    environment:
-      POSTGRES_DB: users
-      POSTGRES_USER: user_admin
-      POSTGRES_PASSWORD: secure_users_2024
-      POSTGRES_MAX_CONNECTIONS: "200"
-      POSTGRES_SHARED_BUFFERS: "256MB"
-    volumes:
-      - "user-data:/var/lib/postgresql/data"
-      - "./backups/users:/backups"
-    networks:
-      - backend-network
-    memory: "512m"
-    restart: "unless-stopped"
-
-  # Product Catalog Service
-  product-catalog-db:
-    engine: postgresql
-    port: 5433
-    environment:
-      POSTGRES_DB: products
-      POSTGRES_USER: product_admin
-      POSTGRES_PASSWORD: secure_products_2024
-      POSTGRES_MAX_CONNECTIONS: "150"
-      POSTGRES_WORK_MEM: "8MB"
-    volumes:
-      - "product-data:/var/lib/postgresql/data"
-      - "./backups/products:/backups"
-    networks:
-      - backend-network
-    memory: "512m"
-    restart: "unless-stopped"
-
-  # Order Management Service
-  order-service-db:
-    engine: postgresql
-    port: 5434
-    environment:
-      POSTGRES_DB: orders
-      POSTGRES_USER: order_admin
-      POSTGRES_PASSWORD: secure_orders_2024
-      POSTGRES_ARCHIVE_MODE: "on"
-      POSTGRES_WAL_LEVEL: "replica"
-    volumes:
-      - "order-data:/var/lib/postgresql/data"
-      - "./backups/orders:/backups"
-    networks:
-      - backend-network
-    memory: "512m"
-    restart: "unless-stopped"
-
-  # Search Engine
-  product-search:
+  search:
     engine: meilisearch
-    port: 7700
     environment:
-      MEILI_MASTER_KEY: "search_master_key_2024"
-      MEILI_ENV: "development"
-      MEILI_HTTP_ADDR: "0.0.0.0:7700"
-      MEILI_DB_PATH: "/data.ms"
-    volumes:
-      - "search-data:/data.ms"
-    networks:
-      - frontend-network
-      - backend-network
-    memory: "256m"
-    restart: "unless-stopped"
-
-  # Session Store & Cache
-  redis-cache:
-    engine: redis
-    port: 6379
-    environment:
-      REDIS_PASSWORD: "cache_password_2024"
-      REDIS_MAXMEMORY: "512mb"
-      REDIS_MAXMEMORY_POLICY: "allkeys-lru"
-      REDIS_AOF_ENABLED: "yes"
-      REDIS_DATABASES: "16"
-    volumes:
-      - "cache-data:/data"
-    networks:
-      - cache-network
-      - backend-network
-    memory: "512m"
-    restart: "unless-stopped"
-
-  # Analytics & Metrics
-  analytics-db:
-    engine: influxdb2
-    port: 8086
-    environment:
-      DOCKER_INFLUXDB_INIT_MODE: "setup"
-      DOCKER_INFLUXDB_INIT_USERNAME: "analytics_admin"
-      DOCKER_INFLUXDB_INIT_PASSWORD: "analytics_password_2024"
-      DOCKER_INFLUXDB_INIT_ORG: "ecommerce-org"
-      DOCKER_INFLUXDB_INIT_BUCKET: "user-analytics"
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: "analytics-token-super-secret-2024"
-      INFLUXDB_DATA_RETENTION_CHECK_PERIOD: "1h"
-    volumes:
-      - "analytics-data:/var/lib/influxdb2"
-      - "./backups/analytics:/backups"
-    networks:
-      - backend-network
-    memory: "512m"
-    restart: "unless-stopped"
-
-global:
-  network:
-    frontend-network:
-      driver: bridge
-    backend-network:
-      driver: bridge
-      internal: true
-    cache-network:
-      driver: bridge
-      internal: true
+      MEILI_MASTER_KEY: dev_master_key
+      MEILI_ENV: development
 ```
 
-**What this provides:**
-- ✅ 6 specialized databases for different services
-- ✅ Network isolation (frontend, backend, cache)
-- ✅ Dedicated volumes for data persistence
-- ✅ Service-specific optimizations
-- ✅ Backup strategies for each service
-- ✅ Memory limits and restart policies
-
-**Usage:**
-```bash
-# Initialize all services
-hayai init --config .hayaidb
-
-# Start specific services
-hayai start --config .hayaidb --database user-service-db
-hayai start --config .hayaidb --database product-catalog-db
-
-# Start all services
-hayai start --config .hayaidb
-
-# Check status
-hayai list --config .hayaidb
-```
-
-**Perfect for:**
-- E-commerce platforms
-- Microservices architectures
-- Multi-team development
-- Production-ready applications
-- Scalable web applications
-
----
-
-### **Case 3: Enterprise Data Platform**
-*Complexity Level: 🔴 Advanced*
-
-Enterprise-grade data platform with multiple environments, replication, and advanced configurations.
+### AI/analytics stack
 
 ```yaml
 version: "1.0"
-project: enterprise-data-platform
-description: "Enterprise data platform with multi-environment support"
-
-# Global network configuration
-networks:
-  - data-ingestion-network
-  - data-processing-network
-  - data-analytics-network
-  - monitoring-network
-  - external-network
-
-# Global volume configuration
-volumes:
-  - primary-postgres-data
-  - replica-postgres-data
-  - timeseries-data
-  - vector-data
-  - search-data
-  - cache-cluster-data
-  - analytics-data
-  - monitoring-data
+project: ml-experiments
 
 databases:
-  # PRIMARY DATABASE CLUSTER
-  primary-postgres:
-    engine: postgresql
-    port: 5432
-    environment:
-      # Database Configuration
-      POSTGRES_DB: enterprise_primary
-      POSTGRES_USER: db_admin
-      POSTGRES_PASSWORD: "${POSTGRES_ADMIN_PASSWORD}"
-      POSTGRES_REPLICATION_USER: replicator
-      POSTGRES_REPLICATION_PASSWORD: "${POSTGRES_REPLICATION_PASSWORD}"
-      
-      # Performance Optimization
-      POSTGRES_SHARED_BUFFERS: "1GB"
-      POSTGRES_EFFECTIVE_CACHE_SIZE: "3GB"
-      POSTGRES_WORK_MEM: "16MB"
-      POSTGRES_MAINTENANCE_WORK_MEM: "256MB"
-      POSTGRES_CHECKPOINT_SEGMENTS: "32"
-      POSTGRES_CHECKPOINT_COMPLETION_TARGET: "0.7"
-      POSTGRES_WAL_BUFFERS: "16MB"
-      
-      # Connection & Security
-      POSTGRES_MAX_CONNECTIONS: "500"
-      POSTGRES_LISTEN_ADDRESSES: "*"
-      POSTGRES_SSL: "on"
-      POSTGRES_SSL_CERT_FILE: "/etc/ssl/certs/postgresql.crt"
-      POSTGRES_SSL_KEY_FILE: "/etc/ssl/private/postgresql.key"
-      
-      # Replication Configuration
-      POSTGRES_WAL_LEVEL: "replica"
-      POSTGRES_ARCHIVE_MODE: "on"
-      POSTGRES_ARCHIVE_COMMAND: "cp %p /archives/%f"
-      POSTGRES_MAX_WAL_SENDERS: "3"
-      POSTGRES_WAL_KEEP_SEGMENTS: "64"
-      
-      # Monitoring & Logging
-      POSTGRES_LOG_DESTINATION: "stderr,csvlog"
-      POSTGRES_LOGGING_COLLECTOR: "on"
-      POSTGRES_LOG_DIRECTORY: "/var/log/postgresql"
-      POSTGRES_LOG_STATEMENT: "ddl"
-      POSTGRES_LOG_MIN_DURATION_STATEMENT: "500"
-      POSTGRES_LOG_LINE_PREFIX: "%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h"
-      
-    volumes:
-      - "primary-postgres-data:/var/lib/postgresql/data"
-      - "./ssl/postgresql:/etc/ssl"
-      - "./backups/primary:/backups"
-      - "./archives/primary:/archives"
-      - "./logs/primary:/var/log/postgresql"
-    networks:
-      - data-ingestion-network
-      - data-processing-network
-      - monitoring-network
-    memory: "2g"
-    cpu_limit: "2"
-    restart: "unless-stopped"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U db_admin -d enterprise_primary"]
-      interval: "10s"
-      timeout: "5s"
-      retries: 5
-      start_period: "30s"
-
-  # READ REPLICA DATABASE
-  replica-postgres:
-    engine: postgresql
-    port: 5433
-    environment:
-      POSTGRES_DB: enterprise_replica
-      POSTGRES_USER: db_readonly
-      POSTGRES_PASSWORD: "${POSTGRES_READONLY_PASSWORD}"
-      POSTGRES_MASTER_SERVICE: "primary-postgres"
-      POSTGRES_REPLICA_MODE: "slave"
-      POSTGRES_MASTER_PORT: "5432"
-      POSTGRES_SHARED_BUFFERS: "512MB"
-      POSTGRES_EFFECTIVE_CACHE_SIZE: "1GB"
-      POSTGRES_MAX_CONNECTIONS: "300"
-    volumes:
-      - "replica-postgres-data:/var/lib/postgresql/data"
-      - "./backups/replica:/backups"
-    networks:
-      - data-analytics-network
-      - monitoring-network
-    memory: "1g"
-    restart: "unless-stopped"
-    depends_on:
-      - primary-postgres
-
-  # TIME SERIES DATA WAREHOUSE
-  timeseries-warehouse:
-    engine: influxdb2
-    port: 8086
-    environment:
-      # Advanced InfluxDB Configuration
-      DOCKER_INFLUXDB_INIT_MODE: "setup"
-      DOCKER_INFLUXDB_INIT_USERNAME: "influx_admin"
-      DOCKER_INFLUXDB_INIT_PASSWORD: "${INFLUXDB_ADMIN_PASSWORD}"
-      DOCKER_INFLUXDB_INIT_ORG: "enterprise"
-      DOCKER_INFLUXDB_INIT_BUCKET: "metrics"
-      DOCKER_INFLUXDB_INIT_RETENTION: "30d"
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: "${INFLUXDB_ADMIN_TOKEN}"
-      
-      # Performance Configuration
-      INFLUXDB_DATA_CACHE_MAX_MEMORY_SIZE: "2gb"
-      INFLUXDB_DATA_CACHE_SNAPSHOT_MEMORY_SIZE: "100mb"
-      INFLUXDB_DATA_CACHE_SNAPSHOT_WRITE_COLD_DURATION: "5m"
-      INFLUXDB_DATA_COMPACT_FULL_WRITE_COLD_DURATION: "2h"
-      INFLUXDB_DATA_MAX_SERIES_PER_DATABASE: "10000000"
-      INFLUXDB_DATA_MAX_VALUES_PER_TAG: "1000000"
-      
-      # Retention Policies
-      INFLUXDB_DATA_RETENTION_CHECK_PERIOD: "10m"
-      INFLUXDB_CONTINUOUS_QUERIES_ENABLED: "true"
-      INFLUXDB_CONTINUOUS_QUERIES_LOG_ENABLED: "true"
-      
-      # HTTP & Security
-      INFLUXDB_HTTP_BIND_ADDRESS: ":8086"
-      INFLUXDB_HTTP_AUTH_ENABLED: "true"
-      INFLUXDB_HTTP_LOG_ENABLED: "true"
-      INFLUXDB_HTTP_HTTPS_ENABLED: "true"
-      INFLUXDB_HTTP_HTTPS_CERTIFICATE: "/etc/ssl/influxdb.crt"
-      INFLUXDB_HTTP_HTTPS_PRIVATE_KEY: "/etc/ssl/influxdb.key"
-      
-    volumes:
-      - "timeseries-data:/var/lib/influxdb2"
-      - "./ssl/influxdb:/etc/ssl"
-      - "./backups/timeseries:/backups"
-      - "./config/influxdb:/etc/influxdb2"
-    networks:
-      - data-ingestion-network
-      - data-analytics-network
-      - monitoring-network
-    memory: "2g"
-    cpu_limit: "2"
-    restart: "unless-stopped"
-
-  # VECTOR DATABASE FOR AI/ML
-  vector-database:
+  vectors:
     engine: qdrant
-    port: 6333
+
+  metrics:
+    engine: influxdb2
     environment:
-      QDRANT_SERVICE_HTTP_PORT: "6333"
-      QDRANT_SERVICE_GRPC_PORT: "6334"
-      QDRANT_LOG_LEVEL: "INFO"
-      QDRANT_STORAGE_PATH: "/qdrant/storage"
-      QDRANT_SNAPSHOTS_PATH: "/qdrant/snapshots"
-      QDRANT_SERVICE_ENABLE_CORS: "true"
-      QDRANT_CLUSTER_ENABLED: "true"
-      QDRANT_CLUSTER_NODE_ID: "1"
-      QDRANT_SERVICE_API_KEY: "${QDRANT_API_KEY}"
-      QDRANT_TLS_CERT: "/etc/ssl/qdrant.crt"
-      QDRANT_TLS_KEY: "/etc/ssl/qdrant.key"
-    volumes:
-      - "vector-data:/qdrant/storage"
-      - "./backups/vector:/qdrant/snapshots"
-      - "./ssl/qdrant:/etc/ssl"
-    networks:
-      - data-analytics-network
-      - external-network
-    memory: "1g"
-    restart: "unless-stopped"
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: dev_password_123
+      DOCKER_INFLUXDB_INIT_ORG: my-org
+      DOCKER_INFLUXDB_INIT_BUCKET: metrics
 
-  # ENTERPRISE SEARCH ENGINE
-  enterprise-search:
-    engine: meilisearch
-    port: 7700
-    environment:
-      MEILI_MASTER_KEY: "${MEILISEARCH_MASTER_KEY}"
-      MEILI_ENV: "production"
-      MEILI_HTTP_ADDR: "0.0.0.0:7700"
-      MEILI_DB_PATH: "/data.ms"
-      MEILI_SNAPSHOT_DIR: "/snapshots"
-      MEILI_DUMPS_DIR: "/dumps"
-      MEILI_LOG_LEVEL: "INFO"
-      MEILI_MAX_INDEXING_MEMORY: "1gb"
-      MEILI_MAX_INDEXING_THREADS: "4"
-      MEILI_SSL_CERT_PATH: "/etc/ssl/meilisearch.crt"
-      MEILI_SSL_KEY_PATH: "/etc/ssl/meilisearch.key"
-    volumes:
-      - "search-data:/data.ms"
-      - "./backups/search:/snapshots"
-      - "./dumps/search:/dumps"
-      - "./ssl/meilisearch:/etc/ssl"
-    networks:
-      - data-analytics-network
-      - external-network
-    memory: "1g"
-    restart: "unless-stopped"
-
-  # REDIS CLUSTER FOR CACHING
-  redis-cluster-master:
-    engine: redis
-    port: 6379
-    environment:
-      REDIS_PASSWORD: "${REDIS_CLUSTER_PASSWORD}"
-      REDIS_MAXMEMORY: "1gb"
-      REDIS_MAXMEMORY_POLICY: "allkeys-lru"
-      REDIS_AOF_ENABLED: "yes"
-      REDIS_RDB_ENABLED: "yes"
-      REDIS_SAVE: "900 1 300 10 60 10000"
-      REDIS_CLUSTER_ENABLED: "yes"
-      REDIS_CLUSTER_CONFIG_FILE: "/etc/redis/nodes.conf"
-      REDIS_CLUSTER_NODE_TIMEOUT: "15000"
-      REDIS_CLUSTER_ANNOUNCE_IP: "redis-cluster-master"
-      REDIS_CLUSTER_ANNOUNCE_PORT: "6379"
-      REDIS_CLUSTER_ANNOUNCE_BUS_PORT: "16379"
-      REDIS_TLS_CERT_FILE: "/etc/ssl/redis.crt"
-      REDIS_TLS_KEY_FILE: "/etc/ssl/redis.key"
-      REDIS_TLS_CA_CERT_FILE: "/etc/ssl/ca.crt"
-    volumes:
-      - "cache-cluster-data:/data"
-      - "./config/redis:/etc/redis"
-      - "./ssl/redis:/etc/ssl"
-    networks:
-      - data-processing-network
-      - external-network
-    memory: "1g"
-    restart: "unless-stopped"
-
-  # ANALYTICS DATABASE
-  analytics-warehouse:
-    engine: questdb
-    port: 9000
-    environment:
-      QUESTDB_HTTP_BIND_TO: "0.0.0.0:9000"
-      QUESTDB_PG_BIND_TO: "0.0.0.0:8812"
-      QUESTDB_ILP_BIND_TO: "0.0.0.0:9009"
-      QUESTDB_HTTP_SECURITY_READONLY: "false"
-      QUESTDB_PG_USER: "questdb_user"
-      QUESTDB_PG_PASSWORD: "${QUESTDB_PASSWORD}"
-      QUESTDB_TELEMETRY_ENABLED: "false"
-      QUESTDB_LOG_LEVEL: "INFO"
-      QUESTDB_SHARED_WORKER_COUNT: "4"
-      QUESTDB_HTTP_WORKER_COUNT: "4"
-    volumes:
-      - "analytics-data:/var/lib/questdb"
-      - "./backups/analytics:/backups"
-    networks:
-      - data-analytics-network
-      - monitoring-network
-    memory: "1g"
-    restart: "unless-stopped"
-
-# Global configuration for enterprise setup
-global:
-  # Network configuration
-  networks:
-    data-ingestion-network:
-      driver: bridge
-      ipam:
-        config:
-          - subnet: "172.21.0.0/16"
-    data-processing-network:
-      driver: bridge
-      internal: true
-      ipam:
-        config:
-          - subnet: "172.22.0.0/16"
-    data-analytics-network:
-      driver: bridge
-      internal: true
-      ipam:
-        config:
-          - subnet: "172.23.0.0/16"
-    monitoring-network:
-      driver: bridge
-      ipam:
-        config:
-          - subnet: "172.24.0.0/16"
-    external-network:
-      driver: bridge
-      ipam:
-        config:
-          - subnet: "172.25.0.0/16"
-
-  # Volume configuration
-  volumes:
-    driver: local
-    driver_opts:
-      type: "ext4"
-      device: "/dev/disk/by-label/enterprise-data"
-
-  # Security configuration
-  security:
-    enable_ssl: true
-    ssl_cert_path: "./ssl"
-    enable_secrets: true
-    secrets_backend: "vault"
-
-  # Backup configuration
-  backup:
-    enabled: true
-    schedule: "0 2 * * *"  # Daily at 2 AM
-    retention: "30d"
-    compression: "gzip"
-    encryption: true
-
-  # Monitoring configuration
-  monitoring:
-    enabled: true
-    prometheus_port: 9090
-    grafana_port: 3000
-    alertmanager_port: 9093
-
-  # Resource limits
-  resources:
-    default_memory: "512m"
-    default_cpu_limit: "1"
-    max_memory: "4g"
-    max_cpu_limit: "4"
+  scratchpad:
+    engine: duckdb     # embedded — just a file, no port needed
 ```
 
-**What this provides:**
-- ✅ Primary-replica PostgreSQL setup
-- ✅ Multi-specialized databases (time series, vector, search)
-- ✅ SSL/TLS encryption for all services
-- ✅ Network isolation with custom subnets
-- ✅ Environment variable management
-- ✅ Backup and monitoring strategies
-- ✅ Resource limits and health checks
-- ✅ Cluster configurations
+### Notes on environment variables
 
-**Usage:**
-```bash
-# Set environment variables
-export POSTGRES_ADMIN_PASSWORD="super_secure_password"
-export POSTGRES_REPLICATION_PASSWORD="replication_password"
-export INFLUXDB_ADMIN_TOKEN="super_secret_token"
+Use the variables the official Docker image of each engine actually reads,
+e.g.:
 
-# Initialize entire platform
-hayai init --config .hayaidb
+- `postgresql` / `timescaledb`: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
+- `mariadb`: `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`
+- `influxdb2`: the `DOCKER_INFLUXDB_INIT_*` family
+- `meilisearch`: `MEILI_MASTER_KEY`, `MEILI_ENV`
 
-# Start core services first
-hayai start --config .hayaidb --database primary-postgres
-hayai start --config .hayaidb --database replica-postgres
+Variables an image doesn't recognize are passed through but have no effect.
 
-# Start analytics services
-hayai start --config .hayaidb --database timeseries-warehouse
-hayai start --config .hayaidb --database vector-database
+## ⚠️ Security Reminder
 
-# Start all services
-hayai start --config .hayaidb
-
-# Monitor status
-hayai list --config .hayaidb --verbose
-```
-
-**Perfect for:**
-- Enterprise applications
-- Big data platforms
-- AI/ML production environments
-- Multi-tenant systems
-- High-availability requirements
-- Compliance-heavy industries
-
-## 🔗 Related Commands
-
-- `hayai init --help` - Initialize database help
-- `hayai config --help` - Configuration management
-- `hayai validate --help` - Configuration validation
-- `hayai list --help` - List databases help
-
----
-
-*For more information, visit the [Hayai Documentation](https://github.com/hitoshyamamoto/hayai) or run `hayai --help`.* 
+`.hayaidb` files contain development credentials in plain text by design.
+Keep production secrets out of them, and see [SECURITY.md](SECURITY.md) for
+hayai's threat model.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   
   ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)
   ![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
-  ![Databases](https://img.shields.io/badge/Databases-19-success)
+  ![Databases](https://img.shields.io/badge/Databases-22-success)
   ![CLI](https://img.shields.io/badge/CLI-Tool-blue)
   
   ![Security](https://img.shields.io/badge/Security-0%20vulnerabilities-brightgreen)
@@ -89,12 +89,12 @@ hayai studio
 
 ## 🎯 Key Features
 
-- **🔓 100% Open-Source**: Only includes databases with permissive licenses
+- **🔓 Open-Source Focused**: Open-source engines (one source-available: TimescaleDB)
 - **⚡ One Command Setup**: Initialize any database with a single command
 - **🐳 Docker-Powered**: Automated container management with health checks
+- **📁 Embedded Engines as Files**: SQLite, DuckDB, LevelDB, and LMDB are managed as plain host files — no container overhead
 - **🔧 Smart Port Management**: Intelligent port allocation (5000-6000 range)
-- **🌐 Admin Dashboards**: Built-in web interfaces for database management
-- **🔗 Environment Integration**: Automatic `.env` file updates with connection URIs
+- **🌐 Admin Dashboards**: One-command access to the web UIs that engines ship built-in (Qdrant, ArangoDB, InfluxDB, QuestDB, Meilisearch, VictoriaMetrics)
 - **✨ Modern CLI**: Interactive prompts with beautiful output
 
 ## 📦 Supported Databases
@@ -202,9 +202,8 @@ hayai --version
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `hayai init --config .hayaidb` | Initialize from configuration file | `hayai init --config .hayaidb` |
-| `hayai validate --config .hayaidb` | Validate configuration file | `hayai validate --config .hayaidb` |
-| `hayai config check` | Check configuration syntax | `hayai config check` |
+| `hayai export` | Export current databases to a `.hayaidb` file | `hayai export -o .hayaidb` |
+| `hayai sync` | Create databases from a `.hayaidb` file | `hayai sync --dry-run` |
 
 📚 **See [HAYAIDB.md](HAYAIDB.md) for complete configuration file documentation**
 
@@ -212,11 +211,12 @@ hayai --version
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `hayai remove <name>` | Remove database instance | `hayai remove mydb --force` |
-| `hayai logs <name>` | View database logs | `hayai logs mydb --follow` |
-| `hayai snapshot <name>` | Create database snapshot | `hayai snapshot mydb --compress` |
+| `hayai remove <name>` | Remove database instance | `hayai remove mydb --keep-data` |
+| `hayai logs <name>` | Stream database container logs | `hayai logs mydb --follow` |
+| `hayai snapshot <name>` | Create database snapshot | `hayai snapshot mydb` |
 | `hayai clone <options>` | Clone database instances | `hayai clone --from prod --to staging` |
-| `hayai merge <options>` | Merge two databases bidirectionally | `hayai merge --source dbA --target dbB --preview` |
+| `hayai merge <options>` | Merge a source database into a target | `hayai merge --source dbA --target dbB --preview` |
+| `hayai migrate <options>` | Plan a cross-engine migration (validation + guidance; execution not yet implemented) | `hayai migrate -f db1 -t db2 -e influxdb3 --dry-run` |
 
 📸 **For complete backup and snapshot documentation, see: [ABOUT_BACKUP.md](ABOUT_BACKUP.md)**
 
@@ -232,11 +232,8 @@ hayai init
 # Quick setup
 hayai init -n mydb -e postgresql -p 5432 -y
 
-# With admin dashboard
-hayai init --admin-dashboard
-
-# Custom configuration
-hayai init -n cache -e redis -p 6379 --memory 512mb
+# Redis cache
+hayai init -n cache -e redis -y
 ```
 
 **Options:**
@@ -244,7 +241,6 @@ hayai init -n cache -e redis -p 6379 --memory 512mb
 - `-e, --engine <engine>` - Database engine
 - `-p, --port <port>` - Port number
 - `-y, --yes` - Skip confirmations
-- `--admin-dashboard` - Enable admin dashboard
 </details>
 
 <details>
@@ -256,9 +252,6 @@ hayai start
 
 # Start specific database
 hayai start mydb
-
-# Start with custom options
-hayai start --detach --timeout 60
 ```
 </details>
 
@@ -289,7 +282,7 @@ hayai clone -f prod -t staging --force -y
 - `--force` - Overwrite existing target databases
 - `--dry-run` - Show what would be cloned without executing
 
-**Supported Engines:** PostgreSQL, MariaDB, Redis, SQLite, DuckDB, and all other engines with generic data copying.
+**Supported Engines:** PostgreSQL, MariaDB, Redis (native tooling); SQLite, DuckDB, LevelDB, LMDB (host file copy). Other engines require manual cloning with their native tools — the command prints guidance.
 </details>
 
 <details>
@@ -317,12 +310,11 @@ hayai merge -s dbA -t dbB --execute --force
 - `--force` - Skip confirmation prompts
 
 **How Merge Works:**
-- Data from source is copied to target
-- Data from target is copied to source  
-- Both databases end up with combined data
-- Conflicts are resolved automatically when possible
+- Data from the source is copied into the target
+- The source database is left unchanged
+- Conflicts are resolved in favor of the source when possible
 
-**Supported Engines:** PostgreSQL (SQL-level), MariaDB (SQL-level), Redis (key-level with REPLACE), others (generic file-based).
+**Supported Engines:** PostgreSQL (SQL-level), MariaDB (SQL-level), Redis (key-level via native MIGRATE), others (generic file-based, best-effort).
 </details>
 
 <details>
@@ -337,9 +329,6 @@ hayai list --running
 
 # JSON output
 hayai list --format json
-
-# Detailed view
-hayai list --verbose
 ```
 </details>
 
@@ -405,14 +394,14 @@ databases:
 
 ### 🔧 **Usage**
 ```bash
-# Initialize all databases from .hayaidb
-hayai init --config .hayaidb
+# Create all databases declared in .hayaidb (skips ones that exist)
+hayai sync
 
-# Start all databases
-hayai start --config .hayaidb
+# Preview what sync would create
+hayai sync --dry-run
 
-# Stop all databases
-hayai stop --config .hayaidb
+# Export your current databases to a .hayaidb file
+hayai export
 ```
 
 📚 **For complete documentation and examples, see: [HAYAIDB.md](HAYAIDB.md)**
@@ -477,7 +466,7 @@ hayai init -n graph -e arangodb -p 8529 -y
 - **Interactive CLI** - Beautiful prompts with validation
 - **Smart Defaults** - Sensible configuration out of the box
 - **Error Handling** - Clear error messages and recovery suggestions
-- **Auto-completion** - Shell completion support
+- **Honest Output** - Commands report what actually happened, and unimplemented paths say so
 
 ### 🚀 Performance & Flexibility
 - **Fast Setup** - Databases ready in seconds
@@ -495,20 +484,14 @@ hayai init -n graph -e arangodb -p 8529 -y
 ## 🔄 Dependency Management
 
 ### Core Dependencies
-- **chalk** ^5.4.1 - Terminal colors and styling
-- **commander** ^12.1.0 - Command-line interface framework
-- **dockerode** ^4.0.7 - Docker Engine API client
-- **inquirer** ^9.2.12 - Interactive command-line prompts
-- **ora** ^8.2.0 - Loading spinners and progress indicators
-- **yaml** ^2.8.0 - YAML parser and stringifier
+- **chalk** - Terminal colors and styling
+- **commander** - Command-line interface framework
+- **inquirer** - Interactive command-line prompts
+- **ora** - Loading spinners and progress indicators
+- **yaml** - YAML parser and stringifier
 
-### Development Dependencies
-- **typescript** ^5.8.3 - TypeScript compiler
-- **@types/node** ^22.10.6 - Node.js type definitions
-- **eslint** ^8.57.1 - Code linting
-- **jest** ^29.7.0 - Testing framework
-
-All dependencies are regularly updated and security-audited.
+Docker is driven through the `docker` CLI (Compose V2), so there is no
+Docker SDK dependency. `npm audit` currently reports 0 vulnerabilities.
 
 ## 🎨 Project Branding
 

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -269,8 +269,6 @@ export const snapshotCommand = new Command('snapshot')
   .description('Create snapshots of database instances')
   .argument('<name>', 'Database instance name')
   .option('-o, --output <path>', 'Output directory for snapshots', './snapshots')
-  .option('-c, --compress', 'Compress the snapshot')
-  .option('--format <format>', 'Snapshot format (sql, rdb, tar)', 'sql')
   .action(async (name: string, options: SnapshotOptions) => {
     try {
       const dockerManager = getDockerManager();
@@ -297,12 +295,11 @@ export const snapshotCommand = new Command('snapshot')
       const snapshotName = `${name}-snapshot-${timestamp}`;
       const outputDir = options.output || path.join(process.cwd(), 'snapshots');
       
-      // Determine file extension based on database type and format
+      // The extension follows the engine's native backup format
       let extension = 'sql';
       if (instance.engine === 'redis') extension = 'rdb';
       if (instance.engine.includes('influx') || instance.engine === 'cassandra') extension = 'tar.gz';
       if (EMBEDDED_ENGINES.has(instance.engine)) extension = 'tar.gz';
-      if (options.format === 'tar') extension = 'tar.gz';
       
       const snapshotPath = path.join(outputDir, `${snapshotName}.${extension}`);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -136,8 +136,6 @@ export interface LogOptions extends CLIOptions {
 export interface SnapshotOptions extends CLIOptions {
   name: string;
   output?: string;
-  compress?: boolean;
-  format?: string;
 }
 
 export type CommandResult = {


### PR DESCRIPTION
Closes the documentation half of the audit's honesty findings — net **−1,640 lines** of fiction.

## Changes

- **README** — fixed the 19-vs-22 databases badge; removed claims for features that don't exist (`.env` integration, shell completion, `--admin-dashboard`/`--memory`/`--detach` options, `hayai validate`/`config check`/`init --config` commands); documented the real `export`/`sync` workflow, one-way merge, planner-mode migrate, embedded-as-files engines, and the actual dependency list.
- **CONTRIBUTING / DEVELOPMENT** — dropped the frozen "v0.4.1" headers and stale category counts (the engine list now defers to `templates.ts` as the single source of truth, so it can't drift again); fixed the project tree (listed `src/api`, `src/dashboard`, `src/templates` — none exist — while missing real modules); removed the nonexistent `npm run format`; wrote down the PR/branch workflow and the feat-needs-a-test rule.
- **HAYAIDB.md** (944 → 184 lines) — documented the real `export`/`sync` interface instead of fictional `--config` flags on init/start/stop/list and `hayai validate`; explicit table of which fields are honored vs parsed-but-ignored (`memory`, `networks`, per-db `volumes`, `profiles`).
- **`.hayaidb` sample** — reduced to fields and env vars the engines actually read (the old one carried dozens of `POSTGRES_SHARED_BUFFERS`-style vars the images ignore).
- **ABOUT_BACKUP.md** (535 → 113 lines) — half of it documented an environment-backup system built on `scripts/db-lifecycle.sh`, **a script that doesn't exist in the repo**. Now covers the real snapshot create/list/clean workflow, per-engine formats, honest manual restore instructions, and cron automation with real commands.
- **One small code fix:** removed the decorative `snapshot --compress` (parsed, never used) and `--format tar` (renamed the extension without changing contents — mislabeling SQL dumps as `.tar.gz`).

## Verification

- build / tests (7/7) / lint — clean
- `snapshot --help` shows only real options