### PR TITLE
Verify and fix the Tier 1 data verbs end-to-end (Stage 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-  # Build + test across the supported Node range. 18 is the declared floor
-  # (package.json engines); 22 is current LTS.
+  # Build + test across the supported Node range. 22 is the declared floor
+  # (package.json engines); 24 is current LTS.
   test:
     name: Test (Node ${{ matrix.node-version }})
     needs: quality
@@ -78,6 +78,28 @@ jobs:
           name: coverage
           path: coverage/
           retention-days: 14
+
+  # End-to-end verification of the data verbs (init/start/snapshot/restore/
+  # clone/merge) against real containers for the Tier 1 engines. This is the
+  # trust contract: a green badge means the verbs actually work, not just that
+  # the code compiles. Single job (no matrix) — the suite exercises Docker,
+  # not Node semantics.
+  integration:
+    name: Integration (Tier 1 engines)
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run integration suite
+        run: npm run test:integration
 
   # Catch packaging regressions (missing files, bad bin path) before a tag
   # turns them into a broken npm release.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,6 +5,9 @@ module.exports = {
   
   // Simple test pattern - just look for .test.ts files
   testMatch: ['**/*.test.ts'],
+
+  // Integration tests need Docker and run via jest.integration.config.cjs
+  testPathIgnorePatterns: ['/node_modules/', '/src/tests/integration/'],
   
   // TypeScript transformation
   transform: {

--- a/jest.integration.config.cjs
+++ b/jest.integration.config.cjs
@@ -1,0 +1,31 @@
+/** @type {import('jest').Config} */
+// Integration suite: drives the compiled CLI against real Docker containers.
+// Kept out of the default `jest` run (see testPathIgnorePatterns in
+// jest.config.cjs) because it needs Docker and pulls images; run it with
+// `npm run test:integration`.
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+
+  testMatch: ['**/src/tests/integration/**/*.test.ts'],
+
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      useESM: true,
+    }],
+  },
+
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+
+  collectCoverage: false,
+
+  // Container startup and image pulls dominate; suites run serially because
+  // they share the host Docker daemon and the OS port range.
+  testTimeout: 300000,
+  maxWorkers: 1,
+  clearMocks: true,
+  forceExit: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript-eslint": "^8.61.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev": "tsc && node dist/cli/index.js",
     "test": "jest",
     "test:unit": "jest --testPathPatterns=\"src/tests/unit\" --verbose",
-    "test:integration": "jest --testPathPatterns=\"src/tests/integration\" --verbose --testTimeout=180000",
+    "test:integration": "npm run build && jest --config jest.integration.config.cjs --verbose",
     "test:cli": "jest --testPathPatterns=\"src/tests/cli\" --verbose --testTimeout=120000",
     "test:database": "jest --testPathPatterns=\"src/tests/database-specific\" --verbose --testTimeout=180000",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:cli && npm run test:database",

--- a/src/cli/commands/clone.ts
+++ b/src/cli/commands/clone.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
+import { resolveServiceContainer } from '../../core/containers.js';
 import { getTemplate } from '../../core/templates.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { recordOperation } from '../../core/security.js';
@@ -124,14 +125,16 @@ async function executeClone(sourceInstance: any, targetName: string): Promise<vo
 }
 
 async function cloneData(source: any, target: any): Promise<void> {
-  const sourceContainer = `${source.name}-db`;
-  const targetContainer = `${target.name}-db`;
-
   if (EMBEDDED_ENGINES.has(source.engine)) {
     // Embedded engines are host files — copy the data directory directly
     await cp(source.volume, target.volume, { recursive: true, force: true });
     return;
   }
+
+  // Compose names containers '<project>-<service>-<n>'; resolve the real ones
+  // before any docker exec/cp.
+  const sourceContainer = await resolveServiceContainer(source.name);
+  const targetContainer = await resolveServiceContainer(target.name);
 
   switch (source.engine) {
     case 'postgresql':
@@ -141,7 +144,7 @@ async function cloneData(source: any, target: any): Promise<void> {
       await cloneMariaDB(sourceContainer, targetContainer, source.environment);
       break;
     case 'redis':
-      await cloneRedis(sourceContainer, targetContainer);
+      await cloneRedis(sourceContainer, targetContainer, target.name);
       break;
     default:
       // This situation should never happen due to compatibility validation
@@ -199,7 +202,8 @@ async function cloneMariaDB(
         '-e',
         `MYSQL_PWD=${rootPassword}`,
         sourceContainer,
-        'mysqldump',
+        // mariadb:11 images ship only the mariadb-* client names
+        'mariadb-dump',
         '-u',
         'root',
         ...dumpTarget,
@@ -209,7 +213,7 @@ async function cloneMariaDB(
 
     const restoreProcess = spawn(
       'docker',
-      ['exec', '-i', '-e', `MYSQL_PWD=${rootPassword}`, targetContainer, 'mysql', '-u', 'root'],
+      ['exec', '-i', '-e', `MYSQL_PWD=${rootPassword}`, targetContainer, 'mariadb', '-u', 'root'],
       { stdio: ['pipe', 'inherit', 'pipe'] },
     );
 
@@ -224,64 +228,38 @@ async function cloneMariaDB(
   });
 }
 
-async function cloneRedis(sourceContainer: string, targetContainer: string): Promise<void> {
+function runDockerStep(args: string[], failureMessage: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    // Create RDB backup
-    const bgsaveProcess = spawn('docker', ['exec', sourceContainer, 'redis-cli', 'BGSAVE']);
-
-    bgsaveProcess.on('close', async (code) => {
-      if (code !== 0) {
-        reject(new Error('Redis backup failed'));
-        return;
-      }
-
-      // Wait for backup to complete
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-
-      // Copy RDB file
-      const copyProcess = spawn('docker', [
-        'cp',
-        `${sourceContainer}:/data/dump.rdb`,
-        '/tmp/redis-clone.rdb',
-      ]);
-
-      copyProcess.on('close', (copyCode) => {
-        if (copyCode !== 0) {
-          reject(new Error('Failed to copy Redis data'));
-          return;
-        }
-
-        // Restore to target
-        const restoreProcess = spawn('docker', [
-          'cp',
-          '/tmp/redis-clone.rdb',
-          `${targetContainer}:/data/dump.rdb`,
-        ]);
-
-        restoreProcess.on('close', async (restoreCode) => {
-          if (restoreCode === 0) {
-            // Restart target to load data
-            const dockerManager = getDockerManager();
-            try {
-              await dockerManager.stopDatabase(targetContainer.replace('-db', ''));
-              await dockerManager.startDatabase(targetContainer.replace('-db', ''));
-              resolve();
-            } catch (error) {
-              reject(error);
-            }
-          } else {
-            reject(new Error('Failed to restore Redis data'));
-          }
-        });
-
-        restoreProcess.on('error', reject);
-      });
-
-      copyProcess.on('error', reject);
-    });
-
-    bgsaveProcess.on('error', reject);
+    const child = spawn('docker', args);
+    child.on('close', (code) => (code === 0 ? resolve() : reject(new Error(failureMessage))));
+    child.on('error', reject);
   });
+}
+
+async function cloneRedis(
+  sourceContainer: string,
+  targetContainer: string,
+  targetName: string,
+): Promise<void> {
+  // Persist the source dataset to its RDB file
+  await runDockerStep(['exec', sourceContainer, 'redis-cli', 'BGSAVE'], 'Redis backup failed');
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  await runDockerStep(
+    ['cp', `${sourceContainer}:/data/dump.rdb`, '/tmp/redis-clone.rdb'],
+    'Failed to copy Redis data',
+  );
+
+  // The RDB must land while the target is down: Redis rewrites dump.rdb on
+  // shutdown, so copying into a running server gets clobbered by its own
+  // (empty) dataset when it stops.
+  const dockerManager = getDockerManager();
+  await dockerManager.stopDatabase(targetName);
+  await runDockerStep(
+    ['cp', '/tmp/redis-clone.rdb', `${targetContainer}:/data/dump.rdb`],
+    'Failed to restore Redis data',
+  );
+  await dockerManager.startDatabase(targetName);
 }
 
 async function handleClone(options: CloneOptions): Promise<void> {

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
+import { composeServiceName, resolveServiceContainer } from '../../core/containers.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { recordOperation } from '../../core/security.js';
 import { snapshotInstance } from './snapshot.js';
@@ -45,7 +46,9 @@ async function previewMerge(sourceInstance: any, targetInstance: any): Promise<v
   console.log(chalk.yellow('\n⚠️  Warning:'));
   console.log('  • This operation is irreversible without backups');
   console.log('  • Source and target must run the same supported engine');
-  console.log('  • Data conflicts may need manual resolution');
+  console.log(
+    '  • On key conflicts: PostgreSQL/MariaDB keep the target row; Redis takes the source value',
+  );
 
   console.log(chalk.bold('\nNext Steps:'));
   console.log(`  • Run with ${chalk.cyan('--execute')} to perform the merge`);
@@ -53,8 +56,11 @@ async function previewMerge(sourceInstance: any, targetInstance: any): Promise<v
 }
 
 async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise<void> {
-  const sourceContainer = `${sourceInstance.name}-db`;
-  const targetContainer = `${targetInstance.name}-db`;
+  // Compose names containers '<project>-<service>-<n>'; resolve the real ones
+  // before any docker exec. Network DNS is a different namespace: there the
+  // plain service name still applies (see mergeRedis).
+  const sourceContainer = await resolveServiceContainer(sourceInstance.name);
+  const targetContainer = await resolveServiceContainer(targetInstance.name);
 
   console.log(chalk.cyan(`🔄 Merging ${sourceInstance.name} → ${targetInstance.name}...`));
 
@@ -76,7 +82,7 @@ async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise
       );
       break;
     case 'redis':
-      await mergeRedis(sourceContainer, targetContainer);
+      await mergeRedis(sourceContainer, composeServiceName(targetInstance.name));
       break;
     default:
       // Unreachable: handleMerge validates the engine before calling here.
@@ -97,12 +103,25 @@ async function mergePostgreSQL(
   console.log(chalk.yellow('🔄 Merging PostgreSQL databases...'));
 
   return new Promise((resolve, reject) => {
-    // Simplified merge - in real implementation would be more sophisticated
     const source = getPostgresExecCredentials(sourceEnv);
     const target = getPostgresExecCredentials(targetEnv);
+    // --inserts is load-bearing: the default COPY format is all-or-nothing per
+    // table, so one key collision with existing target rows would discard the
+    // whole table's data. Row-per-INSERT lets conflicting rows fail
+    // individually (target wins) while everything else merges.
     const dumpProcess = spawn(
       'docker',
-      ['exec', sourceContainer, 'pg_dump', '-U', source.user, '-d', source.database, '--data-only'],
+      [
+        'exec',
+        sourceContainer,
+        'pg_dump',
+        '-U',
+        source.user,
+        '-d',
+        source.database,
+        '--data-only',
+        '--inserts',
+      ],
       { stdio: ['inherit', 'pipe', 'pipe'] },
     );
 
@@ -158,7 +177,8 @@ async function mergeMariaDB(
         '-e',
         `MYSQL_PWD=${getMariaDBRootPassword(sourceEnv)}`,
         sourceContainer,
-        'mysqldump',
+        // mariadb:11 images ship only the mariadb-* client names
+        'mariadb-dump',
         '-u',
         'root',
         '--no-create-info',
@@ -176,7 +196,7 @@ async function mergeMariaDB(
         '-e',
         `MYSQL_PWD=${getMariaDBRootPassword(targetEnv)}`,
         targetContainer,
-        'mysql',
+        'mariadb',
         '-u',
         'root',
         '--force',
@@ -196,7 +216,7 @@ async function mergeMariaDB(
   });
 }
 
-async function mergeRedis(sourceContainer: string, targetContainer: string): Promise<void> {
+async function mergeRedis(sourceContainer: string, targetServiceHost: string): Promise<void> {
   console.log(chalk.yellow('🔄 Merging Redis databases...'));
 
   // SCAN instead of KEYS — KEYS blocks the server on large datasets
@@ -208,10 +228,11 @@ async function mergeRedis(sourceContainer: string, targetContainer: string): Pro
   // MIGRATE moves each value container-to-container over the shared compose
   // network, preserving binary data — piping DUMP output through a text
   // pipeline corrupts it. COPY keeps the source intact; REPLACE resolves
-  // conflicts in favor of the source.
+  // conflicts in favor of the source. The target is addressed by its compose
+  // service name, which doubles as its DNS name on the shared network.
   const failed: string[] = [];
   for (const key of keys) {
-    const ok = await migrateRedisKey(sourceContainer, targetContainer, key);
+    const ok = await migrateRedisKey(sourceContainer, targetServiceHost, key);
     if (!ok) {
       failed.push(key);
     }
@@ -254,17 +275,16 @@ async function scanRedisKeys(container: string): Promise<string[]> {
 
 async function migrateRedisKey(
   sourceContainer: string,
-  targetContainer: string,
+  targetServiceHost: string,
   key: string,
 ): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    // The compose service name doubles as the DNS name on the shared network.
     const migrateProcess = spawn('docker', [
       'exec',
       sourceContainer,
       'redis-cli',
       'MIGRATE',
-      targetContainer,
+      targetServiceHost,
       '6379',
       key,
       '0',
@@ -447,7 +467,8 @@ ${chalk.bold('Examples:')}
 ${chalk.bold('How Merge Works:')}
   • Data from the source is copied into the target
   • The source database is left unchanged
-  • Conflicts are resolved in favor of the source when possible
+  • Key conflicts: PostgreSQL/MariaDB keep the target's row; Redis replaces
+    the key with the source's value (MIGRATE … REPLACE)
 
 ${chalk.bold('Supported Engines (same engine on both sides):')}
   • PostgreSQL, MariaDB: SQL-level merging (data-only)

--- a/src/cli/commands/restore.ts
+++ b/src/cli/commands/restore.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import { createReadStream } from 'fs';
 import { spawn } from 'child_process';
 import { getDockerManager } from '../../core/docker.js';
+import { resolveServiceContainer } from '../../core/containers.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { recordOperation } from '../../core/security.js';
 import { DatabaseInstance } from '../../core/types.js';
@@ -101,8 +102,9 @@ async function restoreMariaDB(
 ): Promise<void> {
   const password = getMariaDBRootPassword(env);
   // --all-databases dumps carry their own CREATE DATABASE / USE statements.
+  // mariadb:11 images ship only the mariadb-* client names.
   await restoreViaStdin(
-    ['exec', '-i', '-e', `MYSQL_PWD=${password}`, container, 'mysql', '-u', 'root'],
+    ['exec', '-i', '-e', `MYSQL_PWD=${password}`, container, 'mariadb', '-u', 'root'],
     snapshotPath,
     'MariaDB',
   );
@@ -110,7 +112,8 @@ async function restoreMariaDB(
 
 async function restoreRedis(instanceName: string, snapshotPath: string): Promise<void> {
   const dockerManager = getDockerManager();
-  const container = `${instanceName}-db`;
+  // Resolved via `compose ps -aq`, so the stopped container is still found.
+  const container = await resolveServiceContainer(instanceName);
 
   // Redis only loads an RDB at startup, so swap the file with the server down.
   await dockerManager.stopDatabase(instanceName);
@@ -135,8 +138,6 @@ async function restoreEmbedded(volume: string, snapshotPath: string): Promise<vo
 }
 
 async function restoreInto(instance: DatabaseInstance, snapshotPath: string): Promise<void> {
-  const container = `${instance.name}-db`;
-
   if (EMBEDDED_ENGINES.has(instance.engine)) {
     await restoreEmbedded(instance.volume, snapshotPath);
     return;
@@ -145,10 +146,18 @@ async function restoreInto(instance: DatabaseInstance, snapshotPath: string): Pr
   switch (instance.engine) {
     case 'postgresql':
     case 'timescaledb':
-      await restorePostgreSQL(container, snapshotPath, instance.environment);
+      await restorePostgreSQL(
+        await resolveServiceContainer(instance.name),
+        snapshotPath,
+        instance.environment,
+      );
       break;
     case 'mariadb':
-      await restoreMariaDB(container, snapshotPath, instance.environment);
+      await restoreMariaDB(
+        await resolveServiceContainer(instance.name),
+        snapshotPath,
+        instance.environment,
+      );
       break;
     case 'redis':
       await restoreRedis(instance.name, snapshotPath);

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs/promises';
 import { createWriteStream } from 'fs';
 import { spawn } from 'child_process';
 import { getDockerManager } from '../../core/docker.js';
+import { resolveServiceContainer } from '../../core/containers.js';
 import { getTemplate } from '../../core/templates.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { recordOperation } from '../../core/security.js';
@@ -33,32 +34,36 @@ async function createSnapshot(instance: any, snapshotPath: string): Promise<void
     return;
   }
 
+  // Compose names containers '<project>-<service>-<n>'; resolve the real one
+  // before any docker exec/cp.
+  const container = await resolveServiceContainer(instance.name);
+
   // Choose appropriate backup method based on database type
   switch (instance.engine) {
     case 'postgresql':
     case 'timescaledb':
-      await createPostgreSQLSnapshot(instance.name, snapshotPath, instance.environment);
+      await createPostgreSQLSnapshot(container, snapshotPath, instance.environment);
       break;
     case 'mariadb':
-      await createMariaDBSnapshot(instance.name, snapshotPath, instance.environment);
+      await createMariaDBSnapshot(container, snapshotPath, instance.environment);
       break;
     case 'redis':
-      await createRedisSnapshot(instance.name, snapshotPath);
+      await createRedisSnapshot(container, snapshotPath);
       break;
     case 'influxdb2':
     case 'influxdb3':
-      await createInfluxDBSnapshot(instance.name, snapshotPath);
+      await createInfluxDBSnapshot(container, snapshotPath);
       break;
     case 'cassandra':
-      await createCassandraSnapshot(instance.name, snapshotPath);
+      await createCassandraSnapshot(container, snapshotPath);
       break;
     default:
-      await createGenericSnapshot(instance.name, snapshotPath);
+      await createGenericSnapshot(container, snapshotPath);
   }
 }
 
 async function createPostgreSQLSnapshot(
-  instanceName: string,
+  container: string,
   snapshotPath: string,
   environment: Record<string, string> = {},
 ): Promise<void> {
@@ -66,7 +71,7 @@ async function createPostgreSQLSnapshot(
     const { user, database } = getPostgresExecCredentials(environment);
     const dumpProcess = spawn(
       'docker',
-      ['exec', `${instanceName}-db`, 'pg_dump', '-U', user, '-d', database, '--clean', '--create'],
+      ['exec', container, 'pg_dump', '-U', user, '-d', database, '--clean', '--create'],
       { stdio: ['inherit', 'pipe', 'pipe'] },
     );
 
@@ -83,7 +88,7 @@ async function createPostgreSQLSnapshot(
 }
 
 async function createMariaDBSnapshot(
-  instanceName: string,
+  container: string,
   snapshotPath: string,
   environment: Record<string, string> = {},
 ): Promise<void> {
@@ -95,8 +100,10 @@ async function createMariaDBSnapshot(
         'exec',
         '-e',
         `MYSQL_PWD=${rootPassword}`,
-        `${instanceName}-db`,
-        'mysqldump',
+        container,
+        // mariadb:11 images ship only the mariadb-* client names; the mysql*
+        // compatibility symlinks are gone.
+        'mariadb-dump',
         '-u',
         'root',
         '--all-databases',
@@ -116,10 +123,10 @@ async function createMariaDBSnapshot(
   });
 }
 
-async function createRedisSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
+async function createRedisSnapshot(container: string, snapshotPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     // Create RDB backup
-    const bgsaveProcess = spawn('docker', ['exec', `${instanceName}-db`, 'redis-cli', 'BGSAVE']);
+    const bgsaveProcess = spawn('docker', ['exec', container, 'redis-cli', 'BGSAVE']);
 
     bgsaveProcess.on('close', async (code) => {
       if (code !== 0) {
@@ -131,11 +138,7 @@ async function createRedisSnapshot(instanceName: string, snapshotPath: string): 
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       // Copy RDB file
-      const copyProcess = spawn('docker', [
-        'cp',
-        `${instanceName}-db:/data/dump.rdb`,
-        snapshotPath,
-      ]);
+      const copyProcess = spawn('docker', ['cp', `${container}:/data/dump.rdb`, snapshotPath]);
 
       copyProcess.on('close', (copyCode) => {
         copyCode === 0 ? resolve() : reject(new Error('Failed to copy Redis snapshot'));
@@ -148,15 +151,9 @@ async function createRedisSnapshot(instanceName: string, snapshotPath: string): 
   });
 }
 
-async function createInfluxDBSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
+async function createInfluxDBSnapshot(container: string, snapshotPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const backupProcess = spawn('docker', [
-      'exec',
-      `${instanceName}-db`,
-      'influx',
-      'backup',
-      '/tmp/backup',
-    ]);
+    const backupProcess = spawn('docker', ['exec', container, 'influx', 'backup', '/tmp/backup']);
 
     backupProcess.on('close', async (code) => {
       if (code !== 0) {
@@ -167,7 +164,7 @@ async function createInfluxDBSnapshot(instanceName: string, snapshotPath: string
       // Create tar archive
       const tarProcess = spawn('docker', [
         'exec',
-        `${instanceName}-db`,
+        container,
         'tar',
         '-czf',
         '/tmp/influx-backup.tar.gz',
@@ -183,7 +180,7 @@ async function createInfluxDBSnapshot(instanceName: string, snapshotPath: string
         // Copy to host
         const copyProcess = spawn('docker', [
           'cp',
-          `${instanceName}-db:/tmp/influx-backup.tar.gz`,
+          `${container}:/tmp/influx-backup.tar.gz`,
           snapshotPath,
         ]);
 
@@ -213,11 +210,11 @@ async function createEmbeddedSnapshot(volumePath: string, snapshotPath: string):
   });
 }
 
-async function createGenericSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
+async function createGenericSnapshot(container: string, snapshotPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const backupProcess = spawn('docker', [
       'exec',
-      `${instanceName}-db`,
+      container,
       'tar',
       '-czf',
       '/tmp/backup.tar.gz',
@@ -230,11 +227,7 @@ async function createGenericSnapshot(instanceName: string, snapshotPath: string)
         return;
       }
 
-      const copyProcess = spawn('docker', [
-        'cp',
-        `${instanceName}-db:/tmp/backup.tar.gz`,
-        snapshotPath,
-      ]);
+      const copyProcess = spawn('docker', ['cp', `${container}:/tmp/backup.tar.gz`, snapshotPath]);
 
       copyProcess.on('close', (copyCode) => {
         copyCode === 0 ? resolve() : reject(new Error('Failed to copy generic snapshot'));
@@ -247,9 +240,9 @@ async function createGenericSnapshot(instanceName: string, snapshotPath: string)
   });
 }
 
-async function createCassandraSnapshot(instanceName: string, snapshotPath: string): Promise<void> {
+async function createCassandraSnapshot(container: string, snapshotPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const snapshotProcess = spawn('docker', ['exec', `${instanceName}-db`, 'nodetool', 'snapshot']);
+    const snapshotProcess = spawn('docker', ['exec', container, 'nodetool', 'snapshot']);
 
     snapshotProcess.on('close', (code) => {
       if (code !== 0) {
@@ -259,7 +252,7 @@ async function createCassandraSnapshot(instanceName: string, snapshotPath: strin
 
       const copyProcess = spawn('docker', [
         'exec',
-        `${instanceName}-db`,
+        container,
         'tar',
         '-czf',
         '/tmp/cassandra-snapshot.tar.gz',
@@ -274,7 +267,7 @@ async function createCassandraSnapshot(instanceName: string, snapshotPath: strin
 
         const finalCopyProcess = spawn('docker', [
           'cp',
-          `${instanceName}-db:/tmp/cassandra-snapshot.tar.gz`,
+          `${container}:/tmp/cassandra-snapshot.tar.gz`,
           snapshotPath,
         ]);
 

--- a/src/core/containers.ts
+++ b/src/core/containers.ts
@@ -1,0 +1,49 @@
+import { spawn } from 'child_process';
+import { getComposeFilePath } from './config.js';
+
+// The compose service for an instance. Also its DNS name on the compose
+// network, which is what container-to-container commands (e.g. redis MIGRATE)
+// must use as a host.
+export function composeServiceName(instanceName: string): string {
+  return `${instanceName}-db`;
+}
+
+// Compose v2 names containers '<project>-<service>-<replica>', so a service
+// name is NOT addressable by `docker exec`/`docker cp`. Every host-side data
+// operation must resolve the real container through Compose first. `ps -aq`
+// (not `-q`) so stopped containers resolve too — restore swaps files into a
+// stopped Redis, for example.
+export async function resolveServiceContainer(instanceName: string): Promise<string> {
+  const composeFile = await getComposeFilePath();
+  const service = composeServiceName(instanceName);
+
+  const output = await new Promise<string>((resolve, reject) => {
+    const child = spawn('docker', ['compose', '-f', composeFile, 'ps', '-aq', service], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data) => (stdout += data.toString()));
+    child.stderr.on('data', (data) => (stderr += data.toString()));
+    child.on('close', (code) => {
+      code === 0
+        ? resolve(stdout)
+        : reject(new Error(`Failed to resolve container for '${instanceName}': ${stderr.trim()}`));
+    });
+    child.on('error', reject);
+  });
+
+  const containerId = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)[0];
+
+  if (!containerId) {
+    throw new Error(
+      `No container exists for instance '${instanceName}' — start it with: hayai start ${instanceName}`,
+    );
+  }
+
+  return containerId;
+}

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -210,7 +210,9 @@ export class DockerManager {
     // Docker is ready
     this.dockerVerified = true;
 
-    console.log(chalk.green(`✅ Docker ${result.version} is ready`));
+    // Status chatter goes to stderr so data commands (list --format json,
+    // connect --uri) keep stdout machine-readable.
+    console.error(chalk.green(`✅ Docker ${result.version} is ready`));
   }
 
   private async pathExists(filePath: string): Promise<boolean> {

--- a/src/tests/integration/embedded.test.ts
+++ b/src/tests/integration/embedded.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
+import * as path from 'path';
+import { createProject, destroyProject, latestSnapshot, parseListJson, runCli } from './helpers.js';
+
+/**
+ * End-to-end lifecycle for embedded (file-based) engines, using SQLite as the
+ * representative: init → list → snapshot → corrupt → restore → clone → remove.
+ * DuckDB, LevelDB and LMDB share the exact same host-file code paths.
+ */
+describe('embedded engine lifecycle (sqlite)', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('embedded');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('init creates an embedded instance without a container or port', async () => {
+    const result = await runCli(['init', '-n', 'emb', '-e', 'sqlite', '-y'], projectDir);
+    expect(result.code).toBe(0);
+
+    const instances = JSON.parse(
+      await readFile(path.join(projectDir, 'data', 'instances.json'), 'utf-8'),
+    );
+    expect(instances.emb).toBeDefined();
+    expect(instances.emb.status).toBe('embedded');
+    expect(instances.emb.port).toBe(0);
+  });
+
+  it('list --format json reports the instance with machine-readable output', async () => {
+    const result = await runCli(['list', '--format', 'json'], projectDir);
+    expect(result.code).toBe(0);
+
+    const instances = parseListJson(result);
+    const emb = instances.find((instance) => instance.name === 'emb');
+    expect(emb).toBeDefined();
+    expect(emb?.engine).toBe('sqlite');
+  });
+
+  it('snapshot archives the data directory', async () => {
+    await writeFile(path.join(projectDir, 'data', 'emb', 'emb.db'), 'generation-1');
+
+    const result = await runCli(['snapshot', 'emb'], projectDir);
+    expect(result.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'emb');
+    expect(snapshot).toMatch(/^emb-snapshot-.*\.tar\.gz$/);
+  });
+
+  it('restore returns the data directory to the snapshotted state', async () => {
+    await writeFile(path.join(projectDir, 'data', 'emb', 'emb.db'), 'generation-2-corrupted');
+
+    const snapshot = await latestSnapshot(projectDir, 'emb');
+    const result = await runCli(['restore', snapshot, '-t', 'emb', '--force'], projectDir);
+    expect(result.code).toBe(0);
+
+    const content = await readFile(path.join(projectDir, 'data', 'emb', 'emb.db'), 'utf-8');
+    expect(content).toBe('generation-1');
+  });
+
+  it('clone copies the data files to a new instance', async () => {
+    const result = await runCli(['clone', '-f', 'emb', '-t', 'emb-copy', '-y'], projectDir);
+    expect(result.code).toBe(0);
+
+    const cloneDir = path.join(projectDir, 'data', 'emb-copy');
+    const files = await readdir(cloneDir);
+    expect(files.length).toBeGreaterThan(0);
+
+    const contents = await Promise.all(
+      files.map((file) => readFile(path.join(cloneDir, file), 'utf-8')),
+    );
+    expect(contents).toContain('generation-1');
+  });
+
+  it('remove deletes the instance and its data by default', async () => {
+    const result = await runCli(['remove', 'emb-copy', '--force'], projectDir);
+    expect(result.code).toBe(0);
+
+    const listResult = await runCli(['list', '--format', 'json'], projectDir);
+    const instances = parseListJson(listResult);
+    expect(instances.find((instance) => instance.name === 'emb-copy')).toBeUndefined();
+
+    await expect(readdir(path.join(projectDir, 'data', 'emb-copy'))).rejects.toThrow();
+  });
+
+  it('remove --keep-data preserves the data directory', async () => {
+    await runCli(['clone', '-f', 'emb', '-t', 'emb-keep', '-y'], projectDir);
+    const result = await runCli(['remove', 'emb-keep', '--force', '--keep-data'], projectDir);
+    expect(result.code).toBe(0);
+
+    const files = await readdir(path.join(projectDir, 'data', 'emb-keep'));
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('init refuses a duplicate instance name with a non-zero exit code', async () => {
+    // mkdir keeps the failure path honest even if a previous test failed early
+    await mkdir(path.join(projectDir, 'data', 'emb'), { recursive: true });
+    const result = await runCli(['init', '-n', 'emb', '-e', 'sqlite', '-y'], projectDir);
+    expect(result.code).not.toBe(0);
+  });
+});

--- a/src/tests/integration/helpers.ts
+++ b/src/tests/integration/helpers.ts
@@ -1,0 +1,128 @@
+import { spawn } from 'child_process';
+import { mkdtemp, readdir, rm } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+// Integration tests exercise the compiled CLI exactly as a user (or an
+// orchestrator) would: a real child process, a real cwd, real Docker.
+const CLI_PATH = path.resolve(process.cwd(), 'dist/cli/index.js');
+
+function run(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs = 180_000,
+): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1', CI: 'true' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(
+        new Error(
+          `Timed out after ${timeoutMs}ms: ${command} ${args.join(' ')}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    }, timeoutMs);
+
+    child.stdout.on('data', (data) => (stdout += data.toString()));
+    child.stderr.on('data', (data) => (stderr += data.toString()));
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
+  });
+}
+
+export function runCli(args: string[], cwd: string, timeoutMs?: number): Promise<CliResult> {
+  return run(process.execPath, [CLI_PATH, ...args], cwd, timeoutMs);
+}
+
+export function runDocker(args: string[], cwd: string, timeoutMs?: number): Promise<CliResult> {
+  return run('docker', args, cwd, timeoutMs);
+}
+
+// Every hayai project writes its compose file to the cwd; exec through it so
+// tests address services the same way Compose does, independent of how
+// containers end up being named on the host.
+export function composeExec(
+  projectDir: string,
+  service: string,
+  cmd: string[],
+  timeoutMs?: number,
+): Promise<CliResult> {
+  const composeFile = path.join(projectDir, 'docker-compose.yml');
+  return runDocker(
+    ['compose', '-f', composeFile, 'exec', '-T', service, ...cmd],
+    projectDir,
+    timeoutMs,
+  );
+}
+
+export async function createProject(prefix: string): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), `hayai-it-${prefix}-`));
+}
+
+export async function destroyProject(projectDir: string): Promise<void> {
+  const composeFile = path.join(projectDir, 'docker-compose.yml');
+  // Best-effort teardown: the compose file may not exist if a suite failed early.
+  await runDocker(
+    ['compose', '-f', composeFile, 'down', '-v', '--remove-orphans'],
+    projectDir,
+  ).catch(() => undefined);
+  await rm(projectDir, { recursive: true, force: true });
+}
+
+export async function waitFor(
+  probe: () => Promise<boolean>,
+  label: string,
+  timeoutMs = 120_000,
+  intervalMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      if (await probe()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for: ${label}` +
+      (lastError ? `\nlast error: ${lastError}` : ''),
+  );
+}
+
+// Snapshot filenames embed an ISO timestamp with ':' and '.' replaced by '-',
+// so lexicographic order within one instance prefix is chronological order.
+export async function latestSnapshot(projectDir: string, instanceName: string): Promise<string> {
+  const snapshotsDir = path.join(projectDir, 'snapshots');
+  const files = await readdir(snapshotsDir);
+  const matching = files.filter((file) => file.startsWith(`${instanceName}-snapshot-`)).sort();
+  if (matching.length === 0) {
+    throw new Error(`No snapshot found for '${instanceName}' in ${snapshotsDir}`);
+  }
+  return matching[matching.length - 1];
+}
+
+export function parseListJson(result: CliResult): Array<Record<string, unknown>> {
+  return JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+}

--- a/src/tests/integration/helpers.ts
+++ b/src/tests/integration/helpers.ts
@@ -86,7 +86,27 @@ export async function destroyProject(projectDir: string): Promise<void> {
     ['compose', '-f', composeFile, 'down', '-v', '--remove-orphans'],
     projectDir,
   ).catch(() => undefined);
-  await rm(projectDir, { recursive: true, force: true });
+  try {
+    await rm(projectDir, { recursive: true, force: true });
+  } catch {
+    // Containers write into the bind mount as root, so the host user cannot
+    // unlink those files. Scrub through a throwaway container instead; never
+    // let cleanup failures mask the actual test outcome.
+    await runDocker(
+      [
+        'run',
+        '--rm',
+        '-v',
+        `${projectDir}:/target`,
+        'alpine:latest',
+        'sh',
+        '-c',
+        'rm -rf /target/* /target/.[!.]* 2>/dev/null || true',
+      ],
+      projectDir,
+    ).catch(() => undefined);
+    await rm(projectDir, { recursive: true, force: true }).catch(() => undefined);
+  }
 }
 
 export async function waitFor(

--- a/src/tests/integration/mariadb.test.ts
+++ b/src/tests/integration/mariadb.test.ts
@@ -1,0 +1,89 @@
+import {
+  composeExec,
+  createProject,
+  destroyProject,
+  latestSnapshot,
+  runCli,
+  waitFor,
+} from './helpers.js';
+
+// Defaults declared by the mariadb template in src/core/templates.ts
+const ROOT_PASSWORD = 'rootpassword';
+const DB = 'database';
+
+async function mysql(projectDir: string, service: string, sql: string) {
+  return composeExec(projectDir, service, [
+    'mysql',
+    '-uroot',
+    `-p${ROOT_PASSWORD}`,
+    '-N',
+    '-e',
+    sql,
+    DB,
+  ]);
+}
+
+/**
+ * End-to-end data lifecycle for MariaDB: init → start → seed → snapshot →
+ * destroy data → restore → verify. Exercises the mysqldump/mysql replay path.
+ */
+describe('mariadb data lifecycle', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('mariadb');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('init and start bring up a healthy instance', async () => {
+    const initResult = await runCli(['init', '-n', 'mdb', '-e', 'mariadb', '-y'], projectDir);
+    expect(initResult.code).toBe(0);
+
+    const startResult = await runCli(['start', 'mdb'], projectDir, 300_000);
+    expect(startResult.code).toBe(0);
+
+    await waitFor(
+      async () => (await mysql(projectDir, 'mdb-db', 'SELECT 1;')).code === 0,
+      'mdb to accept connections',
+    );
+  });
+
+  it('seed data is queryable', async () => {
+    const create = await mysql(
+      projectDir,
+      'mdb-db',
+      'CREATE TABLE audit_check (id INT PRIMARY KEY); INSERT INTO audit_check VALUES (1), (2);',
+    );
+    expect(create.code).toBe(0);
+
+    const count = await mysql(projectDir, 'mdb-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+  });
+
+  it('snapshot produces a SQL dump containing the seeded schema', async () => {
+    const result = await runCli(['snapshot', 'mdb'], projectDir);
+    expect(result.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'mdb');
+    expect(snapshot).toMatch(/\.sql$/);
+  });
+
+  it('restore recovers dropped data from the snapshot', async () => {
+    const drop = await mysql(projectDir, 'mdb-db', 'DROP TABLE audit_check;');
+    expect(drop.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'mdb');
+    const result = await runCli(['restore', snapshot, '-t', 'mdb', '--force'], projectDir, 300_000);
+    expect(result.code).toBe(0);
+
+    await waitFor(
+      async () => (await mysql(projectDir, 'mdb-db', 'SELECT 1;')).code === 0,
+      'mdb to accept connections after restore',
+    );
+    const count = await mysql(projectDir, 'mdb-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+  });
+});

--- a/src/tests/integration/mariadb.test.ts
+++ b/src/tests/integration/mariadb.test.ts
@@ -11,9 +11,10 @@ import {
 const ROOT_PASSWORD = 'rootpassword';
 const DB = 'database';
 
+// mariadb:11 images ship only the mariadb-* client names (no mysql symlinks)
 async function mysql(projectDir: string, service: string, sql: string) {
   return composeExec(projectDir, service, [
-    'mysql',
+    'mariadb',
     '-uroot',
     `-p${ROOT_PASSWORD}`,
     '-N',

--- a/src/tests/integration/postgres.test.ts
+++ b/src/tests/integration/postgres.test.ts
@@ -1,0 +1,118 @@
+import { readFile } from 'fs/promises';
+import * as path from 'path';
+import {
+  composeExec,
+  createProject,
+  destroyProject,
+  latestSnapshot,
+  runCli,
+  waitFor,
+} from './helpers.js';
+
+// Defaults declared by the postgresql template in src/core/templates.ts
+const PG_USER = 'admin';
+const PG_DB = 'database';
+
+async function psql(projectDir: string, service: string, sql: string) {
+  return composeExec(projectDir, service, ['psql', '-U', PG_USER, '-d', PG_DB, '-tAc', sql]);
+}
+
+async function waitForPostgres(projectDir: string, service: string) {
+  await waitFor(
+    async () =>
+      (await composeExec(projectDir, service, ['pg_isready', '-U', PG_USER, '-d', PG_DB])).code ===
+      0,
+    `${service} to accept connections`,
+  );
+}
+
+/**
+ * End-to-end data lifecycle for PostgreSQL, the flagship Tier 1 engine:
+ * init → start → seed → snapshot → destroy data → restore → clone → merge.
+ * Every step drives the compiled CLI and verifies real data inside the
+ * containers — this is the trust contract the audit demands.
+ */
+describe('postgresql data lifecycle', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('postgres');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('init and start bring up a healthy instance', async () => {
+    const initResult = await runCli(['init', '-n', 'pg', '-e', 'postgresql', '-y'], projectDir);
+    expect(initResult.code).toBe(0);
+
+    const startResult = await runCli(['start', 'pg'], projectDir, 300_000);
+    expect(startResult.code).toBe(0);
+
+    await waitForPostgres(projectDir, 'pg-db');
+  });
+
+  it('seed data is queryable through the published service', async () => {
+    const create = await psql(
+      projectDir,
+      'pg-db',
+      'CREATE TABLE audit_check (id int PRIMARY KEY); INSERT INTO audit_check VALUES (1), (2);',
+    );
+    expect(create.code).toBe(0);
+
+    const count = await psql(projectDir, 'pg-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+  });
+
+  it('snapshot produces a non-empty SQL dump of the real database', async () => {
+    const result = await runCli(['snapshot', 'pg'], projectDir);
+    expect(result.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'pg');
+    const dump = await readFile(path.join(projectDir, 'snapshots', snapshot), 'utf-8');
+    expect(dump).toContain('audit_check');
+  });
+
+  it('restore recovers dropped data from the snapshot', async () => {
+    const drop = await psql(projectDir, 'pg-db', 'DROP TABLE audit_check;');
+    expect(drop.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'pg');
+    const result = await runCli(['restore', snapshot, '-t', 'pg', '--force'], projectDir, 300_000);
+    expect(result.code).toBe(0);
+
+    await waitForPostgres(projectDir, 'pg-db');
+    const count = await psql(projectDir, 'pg-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+  });
+
+  it('clone creates an independent instance with identical data', async () => {
+    const result = await runCli(['clone', '-f', 'pg', '-t', 'pg-clone', '-y'], projectDir, 300_000);
+    expect(result.code).toBe(0);
+
+    await waitForPostgres(projectDir, 'pg-clone-db');
+    const count = await psql(projectDir, 'pg-clone-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+
+    // Independence: writing to the clone must not touch the source
+    await psql(projectDir, 'pg-clone-db', 'INSERT INTO audit_check VALUES (3);');
+    const sourceCount = await psql(projectDir, 'pg-db', 'SELECT count(*) FROM audit_check;');
+    expect(sourceCount.stdout.trim()).toBe('2');
+  });
+
+  it('merge copies source rows into the target and leaves the source intact', async () => {
+    const result = await runCli(
+      ['merge', '-s', 'pg-clone', '-t', 'pg', '--execute', '--force'],
+      projectDir,
+      300_000,
+    );
+    expect(result.code).toBe(0);
+
+    const targetCount = await psql(projectDir, 'pg-db', 'SELECT count(*) FROM audit_check;');
+    expect(targetCount.stdout.trim()).toBe('3');
+
+    const sourceCount = await psql(projectDir, 'pg-clone-db', 'SELECT count(*) FROM audit_check;');
+    expect(sourceCount.stdout.trim()).toBe('3');
+  });
+});

--- a/src/tests/integration/redis.test.ts
+++ b/src/tests/integration/redis.test.ts
@@ -1,0 +1,74 @@
+import {
+  composeExec,
+  createProject,
+  destroyProject,
+  latestSnapshot,
+  runCli,
+  waitFor,
+} from './helpers.js';
+
+async function redisCli(projectDir: string, service: string, cmd: string[]) {
+  return composeExec(projectDir, service, ['redis-cli', ...cmd]);
+}
+
+/**
+ * End-to-end data lifecycle for Redis: init → start → seed → snapshot (BGSAVE
+ * + RDB copy) → flush → restore (stop, swap RDB, start) → verify.
+ */
+describe('redis data lifecycle', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('redis');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('init and start bring up a healthy instance', async () => {
+    const initResult = await runCli(['init', '-n', 'rd', '-e', 'redis', '-y'], projectDir);
+    expect(initResult.code).toBe(0);
+
+    const startResult = await runCli(['start', 'rd'], projectDir, 300_000);
+    expect(startResult.code).toBe(0);
+
+    await waitFor(
+      async () => (await redisCli(projectDir, 'rd-db', ['ping'])).stdout.includes('PONG'),
+      'rd to accept connections',
+    );
+  });
+
+  it('seed data is readable', async () => {
+    await redisCli(projectDir, 'rd-db', ['SET', 'audit:k1', 'v1']);
+    await redisCli(projectDir, 'rd-db', ['SET', 'audit:k2', 'v2']);
+
+    const get = await redisCli(projectDir, 'rd-db', ['GET', 'audit:k1']);
+    expect(get.stdout.trim()).toBe('v1');
+  });
+
+  it('snapshot captures an RDB file', async () => {
+    const result = await runCli(['snapshot', 'rd'], projectDir);
+    expect(result.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'rd');
+    expect(snapshot).toMatch(/\.rdb$/);
+  });
+
+  it('restore recovers flushed keys from the RDB snapshot', async () => {
+    await redisCli(projectDir, 'rd-db', ['FLUSHALL']);
+    const empty = await redisCli(projectDir, 'rd-db', ['GET', 'audit:k1']);
+    expect(empty.stdout.trim()).toBe('');
+
+    const snapshot = await latestSnapshot(projectDir, 'rd');
+    const result = await runCli(['restore', snapshot, '-t', 'rd', '--force'], projectDir, 300_000);
+    expect(result.code).toBe(0);
+
+    await waitFor(
+      async () => (await redisCli(projectDir, 'rd-db', ['ping'])).stdout.includes('PONG'),
+      'rd to accept connections after restore',
+    );
+    const restored = await redisCli(projectDir, 'rd-db', ['GET', 'audit:k1']);
+    expect(restored.stdout.trim()).toBe('v1');
+  });
+});


### PR DESCRIPTION
## Context

The July 2026 technical audit set one non-negotiable priority (Stage 0): the data verbs hayai advertises must be **verified end-to-end** before anything else is built. Until this PR, `src/tests/integration` was an empty directory referenced by package.json scripts, and no data verb had ever been exercised against a real container in CI.

Running the new suite immediately proved the audit right — and found more than it predicted.

## What this PR does

**1. Adds an end-to-end integration suite for the Tier 1 engines** (`postgresql`, `mariadb`, `redis`, and the embedded path via `sqlite`). Each suite drives the **compiled CLI as a child process** with an isolated working directory — the exact consumption model of a CI job or an orchestrator. The full cycle is exercised: `init → start → seed real data → snapshot → destroy data → restore → verify`, plus clone independence and merge row-count semantics for PostgreSQL. A dedicated `jest.integration.config.cjs` (serial, 300s timeout) keeps the default `npm test` Docker-free.

**2. Fixes the four defects the suite exposed** — every data verb was broken for containerized engines:

| # | Defect | Root cause | Fix |
|---|--------|-----------|-----|
| 1 | `snapshot`/`restore`/`clone`/`merge` failed for **all** containerized engines | Commands ran `docker exec <name>-db`, but Compose v2 names containers `<project>-<service>-<n>`; no `container_name` is set in the generated file | New `core/containers.ts` resolves the real container via `docker compose ps -aq` (`-a` so stopped containers resolve during Redis restore). Redis `MIGRATE` keeps the service name — correct as network DNS |
| 2 | Every MariaDB data operation exited 127 | `mariadb:11` ships only `mariadb`/`mariadb-dump`; the `mysql*` symlinks are gone | Switched to the mariadb-native client names |
| 3 | Redis clone silently produced an empty target | RDB copied into a **running** target; Redis rewrites `dump.rdb` on shutdown, clobbering it | Copy now happens with the target stopped (same sequence restore uses) |
| 4 | PostgreSQL merge copied **nothing** when datasets overlapped | `pg_dump` COPY format is all-or-nothing per table; one key conflict discarded the whole table | `--inserts` lets conflicting rows fail individually (target wins) while new rows land; help text now states the real per-engine conflict semantics |

**3. Fixes stdout pollution**: the `✅ Docker ... is ready` status line corrupted `list --format json` output. Status chatter now goes to stderr; stdout is reserved for data.

**4. Adds an `integration` CI job** so the badge means "the verbs work", not "the code compiles". Runs after the quality gate, parallel to the unit matrix.

## How it was verified

- `npm run test:integration`: **22/22 green** against a live Docker daemon (real image pulls, real containers, real data).
- `npm run lint`, `npm run format:check`, `npx jest --ci` (unit, 10/10): green.
- Defect 1 confirmed empirically before the fix: containers observed as `hayai-it-mariadb-…-mdb-db-1` while commands targeted `mdb-db`.

## Risks and rollback

- Container resolution adds one `docker compose ps` call per data operation — negligible next to dump/restore costs.
- Merge conflict semantics are now **documented as target-wins** for SQL engines (previously claimed source-wins but actually lost data). Behavioral change is strictly additive: rows that previously vanished now merge.
- No schema/state migrations; revert is a clean `git revert` of the four commits.

## Out of scope (next PRs)

- Automation contract: `--json` on all verbs, semantic exit codes, idempotent `init`, state locking (Frente 2).
- Engine tier system and support matrix documentation (Frente 3).
- Embedded engines still require a running Docker daemon for no reason — tracked for Frente 2.
