### PR TITLE
Automation-grade contract: JSON output, exit codes, idempotency, state locking (Stage 0)

### DIFF
--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,0 +1,118 @@
+# Automation Contract
+
+Hayai is built to be driven by orchestrators — an Airflow DAG, a systemd
+timer, a CI job, a shell script. This document is the contract those callers
+script against. Everything here is stable within a major version; changing an
+exit code value or an envelope field is a breaking change.
+
+## The five guarantees
+
+1. **`--json` output with a stable schema** on every state-changing verb.
+2. **Semantic exit codes** — retry decisions can be made from the code alone.
+3. **Idempotent verbs** — retrying a succeeded task does not fail it.
+4. **No prompts in `--json` mode** — a missing confirmation fails fast with a
+   code, never hangs waiting for input.
+5. **Locked state** — concurrent hayai processes cannot corrupt the local
+   inventory (`data/instances.json`, `data/port-allocations.json`,
+   `docker-compose.yml`).
+
+## Exit codes
+
+| Code | Name         | Meaning                                                                 | Retry?                        |
+|------|--------------|-------------------------------------------------------------------------|-------------------------------|
+| 0    | Success      | Operation completed (including honest no-ops like `--exists-ok`)        | —                             |
+| 1    | Error        | Unexpected failure (bug, I/O, engine tooling failed)                    | Maybe                         |
+| 2    | Usage        | Invalid invocation (bad flags, unsupported engine name)                 | Never — fix the call          |
+| 3    | NotFound     | Named instance or snapshot does not exist                               | Never — fix the reference     |
+| 4    | Conflict     | Resource already exists and the verb refuses to overwrite               | Never — use the idempotency flag |
+| 5    | Precondition | Resource exists but is in the wrong state (not running, unsupported engine, missing `--execute`/`--force`) | After fixing the state        |
+| 6    | Environment  | Docker missing, daemon down, or Compose V2 plugin absent                | After fixing the environment  |
+
+## The `--json` envelope
+
+Verbs with `--json` print exactly one JSON document to **stdout**. All human
+chatter (banner, spinners, hints) goes to **stderr**.
+
+```json
+{
+  "ok": true,
+  "command": "init",
+  "data": { "created": true, "instance": { "name": "mydb", "engine": "postgresql", "port": 5000 } }
+}
+```
+
+On failure:
+
+```json
+{
+  "ok": false,
+  "command": "restore",
+  "error": { "code": 3, "message": "Snapshot file not found: nope.sql" }
+}
+```
+
+`data` may appear alongside `error` when partial results exist (e.g. which
+databases a `sync` created before failing).
+
+Supported: `init`, `start`, `stop`, `remove`, `snapshot`, `restore`, `clone`,
+`merge`, `sync`, `export`, `list`.
+
+Two documented exceptions keep their historical raw shapes:
+- `list --format json` — the raw instance array (predates the envelope).
+- `connect --json` — the raw ConnectionInfo object; `connect --uri` prints
+  only the URI.
+
+## Idempotency
+
+| Verb    | Flag           | Behavior on retry                                                        |
+|---------|----------------|--------------------------------------------------------------------------|
+| `init`  | `--exists-ok`  | Instance exists with the same engine → exit 0, `data.created: false`. Different engine → exit 4. |
+| `remove`| `--missing-ok` | Instance absent → exit 0, `data.removed: false`.                          |
+| `start` | (default)      | Starting a running instance is a no-op success (Compose semantics).       |
+| `stop`  | (default)      | Stopping a stopped instance is a no-op success.                           |
+| `sync`  | (default)      | Additive by design: existing instances are skipped, never modified.       |
+
+## Non-interactive mode
+
+`--json` disables every prompt. Where a confirmation would be required
+(`remove`, `restore`, `clone`, `merge --execute`), pass the documented skip
+flag (`--force` / `-y`); otherwise the command exits 5 with a message naming
+the flag. `init --json` requires `--name` and `--engine` (exit 2 otherwise).
+
+## Concurrency
+
+Every state mutation takes an advisory lock (`data/.hayai.lock`) and re-reads
+the state inside it, so concurrent `init`/`remove`/`start`/`stop` calls from
+parallel tasks serialize correctly. Locks held by dead processes, or older
+than 60 s, are broken automatically; acquisition times out after 30 s with
+exit 1.
+
+## Docker requirements
+
+Docker is verified lazily, on the first operation that talks to the daemon.
+`init`, `list`, `connect`, `export` and every operation on embedded engines
+(sqlite, duckdb, leveldb, lmdb) work with no Docker daemon at all. When Docker
+is required and unavailable, commands exit 6.
+
+## Recipes
+
+```bash
+# Idempotent provision inside a retried task
+hayai init -n staging -e postgresql --exists-ok --json
+
+# Gate on state, not on text parsing
+hayai snapshot staging --json || case $? in
+  3) echo "instance gone";;
+  5) echo "instance not running";;
+  6) echo "docker down";;
+esac
+
+# Ephemeral database per pipeline run
+hayai init -n "ci-$BUILD_ID" -e postgresql --exists-ok --json
+hayai start "ci-$BUILD_ID" --json
+# ... run the tests ...
+hayai remove "ci-$BUILD_ID" --force --missing-ok --json
+
+# Export the connection for the app under test
+export DATABASE_URL=$(hayai connect "ci-$BUILD_ID" --uri)
+```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ hayai studio
 - **🔧 Smart Port Management**: Intelligent port allocation (5000-6000 range)
 - **🌐 Admin Dashboards**: One-command access to the web UIs that engines ship built-in (Qdrant, ArangoDB, InfluxDB, QuestDB, Meilisearch, VictoriaMetrics)
 - **✨ Modern CLI**: Interactive prompts with beautiful output
+- **🤖 Automation-Ready**: `--json` envelopes, semantic exit codes, idempotent verbs and state locking — scriptable by CI jobs and orchestrators (see [AUTOMATION.md](AUTOMATION.md))
 
 ## 📦 Supported Databases
 
@@ -540,6 +541,7 @@ npm run lint
 - [Development Guide](DEVELOPMENT.md) - Development setup and workflow
 - [.hayaidb Configuration](HAYAIDB.md) - Declarative database configuration guide
 - [Backup & Snapshots](ABOUT_BACKUP.md) - Complete backup and restoration guide
+- [Automation Contract](AUTOMATION.md) - JSON output, exit codes, idempotency and locking for scripts and orchestrators
 
 ## 📄 License
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "LICENSE",
     "HAYAIDB.md",
     "ABOUT_BACKUP.md",
+    "AUTOMATION.md",
     "CONTRIBUTING.md",
     "DEVELOPMENT.md",
     ".hayaidb",

--- a/src/cli/cli-output.ts
+++ b/src/cli/cli-output.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+import { ExitCode, ExitCodeValue, emitFailure, emitSuccess } from '../core/output.js';
+import { DockerNotReadyError } from '../core/docker.js';
+
+// Shared failure path for every command: in --json mode the envelope goes to
+// stdout (the machine channel) and the human hint to stderr; otherwise both go
+// to stderr. Always exits with the semantic code from AUTOMATION.md.
+export function fail(
+  command: string,
+  code: ExitCodeValue,
+  message: string,
+  jsonMode: boolean,
+  hint?: string,
+): never {
+  if (jsonMode) {
+    emitFailure(command, code, message);
+  }
+  console.error(chalk.red(`❌ ${message}`));
+  if (hint) {
+    console.error(chalk.yellow(`💡 ${hint}`));
+  }
+  process.exit(code);
+}
+
+// Maps thrown errors to the documented exit codes. Commands catch at the top
+// level and route through here so unexpected failures still honor the
+// contract (Environment for Docker being down, Error for everything else).
+export function failFromError(command: string, error: unknown, jsonMode: boolean): never {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error instanceof DockerNotReadyError ? ExitCode.Environment : ExitCode.Error;
+  fail(command, code, message, jsonMode);
+}
+
+export function succeed(command: string, data: unknown, jsonMode: boolean): void {
+  if (jsonMode) {
+    emitSuccess(command, data);
+  }
+}
+
+export { ExitCode };

--- a/src/cli/commands/clone.ts
+++ b/src/cli/commands/clone.ts
@@ -10,6 +10,7 @@ import { recordOperation } from '../../core/security.js';
 import { CLIOptions } from '../../core/types.js';
 import { spawn } from 'child_process';
 import { cp } from 'fs/promises';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 interface CloneOptions extends CLIOptions {
   from: string;
@@ -18,6 +19,7 @@ interface CloneOptions extends CLIOptions {
   confirm?: boolean;
   force?: boolean;
   dryRun?: boolean;
+  json?: boolean;
 }
 
 // Engines with a reliable native clone implementation
@@ -263,33 +265,45 @@ async function cloneRedis(
 }
 
 async function handleClone(options: CloneOptions): Promise<void> {
+  const jsonMode = Boolean(options.json);
   const dockerManager = getDockerManager();
   await dockerManager.initialize();
 
   // Validate source database
   const sourceInstance = dockerManager.getInstance(options.from);
   if (!sourceInstance) {
-    console.error(chalk.red(`❌ Source database '${options.from}' not found`));
-    console.log(chalk.yellow('💡 Run `hayai list` to see available databases'));
-    process.exit(1);
+    fail(
+      'clone',
+      ExitCode.NotFound,
+      `Source database '${options.from}' not found`,
+      jsonMode,
+      'Run `hayai list` to see available databases',
+    );
   }
 
   // Check if source is running (embedded engines have no server to run)
   if (sourceInstance.status !== 'running' && sourceInstance.status !== 'embedded') {
-    console.error(chalk.red(`❌ Source database '${options.from}' must be running`));
-    console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${options.from}`)}`));
-    process.exit(1);
+    fail(
+      'clone',
+      ExitCode.Precondition,
+      `Source database '${options.from}' must be running`,
+      jsonMode,
+      `Start it with: hayai start ${options.from}`,
+    );
   }
 
   // Validate compatibility
   const compatibilityResult = validateCloneCompatibility(sourceInstance.engine);
   if (!compatibilityResult.compatible) {
-    console.error(
-      chalk.red(`❌ Source engine '${sourceInstance.engine}' is not fully compatible for cloning.`),
+    if (!jsonMode) {
+      showManualCloneGuidance(sourceInstance.engine);
+    }
+    fail(
+      'clone',
+      ExitCode.Precondition,
+      `Source engine '${sourceInstance.engine}' is not fully compatible for cloning: ${compatibilityResult.reason}`,
+      jsonMode,
     );
-    console.error(chalk.red(`Reason: ${compatibilityResult.reason}`));
-    showManualCloneGuidance(sourceInstance.engine);
-    process.exit(1);
   }
 
   // Determine target databases
@@ -300,34 +314,60 @@ async function handleClone(options: CloneOptions): Promise<void> {
   } else if (options.toMultiple) {
     targetNames = options.toMultiple.split(',').map((name) => name.trim());
   } else {
-    console.error(chalk.red('❌ Must specify target database(s)'));
-    console.log(chalk.yellow('💡 Use --to or --to-multiple'));
-    process.exit(1);
+    fail(
+      'clone',
+      ExitCode.Usage,
+      'Must specify target database(s)',
+      jsonMode,
+      'Use --to or --to-multiple',
+    );
   }
 
   // Validate target names
   for (const targetName of targetNames) {
     if (dockerManager.getInstance(targetName)) {
       if (!options.force) {
-        console.error(chalk.red(`❌ Target database '${targetName}' already exists`));
-        console.log(chalk.yellow('💡 Use --force to overwrite existing databases'));
-        process.exit(1);
+        fail(
+          'clone',
+          ExitCode.Conflict,
+          `Target database '${targetName}' already exists`,
+          jsonMode,
+          'Use --force to overwrite existing databases',
+        );
       }
     }
   }
 
   // Show preview
-  console.log(chalk.cyan('\n🔍 Clone Preview:'));
-  console.log(chalk.gray(`Source: ${options.from} (${sourceInstance.engine})`));
-  console.log(chalk.gray(`Targets: ${targetNames.join(', ')}`));
+  if (!jsonMode) {
+    console.log(chalk.cyan('\n🔍 Clone Preview:'));
+    console.log(chalk.gray(`Source: ${options.from} (${sourceInstance.engine})`));
+    console.log(chalk.gray(`Targets: ${targetNames.join(', ')}`));
+  }
 
   if (options.dryRun) {
+    if (jsonMode) {
+      succeed(
+        'clone',
+        { dryRun: true, from: options.from, engine: sourceInstance.engine, targets: targetNames },
+        jsonMode,
+      );
+      return;
+    }
     console.log(chalk.yellow('\n🚧 Dry run - no actual cloning performed'));
     return;
   }
 
-  // Confirmation
+  // Confirmation. --json promises non-interactivity: refuse instead of prompting.
   if (!options.confirm && !options.force) {
+    if (jsonMode) {
+      fail(
+        'clone',
+        ExitCode.Precondition,
+        'Clone requires confirmation: pass -y or --force with --json',
+        jsonMode,
+      );
+    }
     const { proceed } = await inquirer.prompt([
       {
         type: 'confirm',
@@ -344,12 +384,14 @@ async function handleClone(options: CloneOptions): Promise<void> {
   }
 
   // Execute clones
-  const spinner = ora('Cloning databases...').start();
+  const spinner = jsonMode ? null : ora('Cloning databases...').start();
 
   try {
     for (let i = 0; i < targetNames.length; i++) {
       const targetName = targetNames[i];
-      spinner.text = `Cloning ${options.from} → ${targetName} (${i + 1}/${targetNames.length})`;
+      if (spinner) {
+        spinner.text = `Cloning ${options.from} → ${targetName} (${i + 1}/${targetNames.length})`;
+      }
 
       // Remove existing if force
       if (options.force && dockerManager.getInstance(targetName)) {
@@ -365,14 +407,23 @@ async function handleClone(options: CloneOptions): Promise<void> {
       });
     }
 
-    spinner.succeed(`Successfully cloned ${options.from} to ${targetNames.length} database(s)`);
+    spinner?.succeed(`Successfully cloned ${options.from} to ${targetNames.length} database(s)`);
+
+    if (jsonMode) {
+      succeed(
+        'clone',
+        { from: options.from, engine: sourceInstance.engine, targets: targetNames },
+        jsonMode,
+      );
+      return;
+    }
 
     console.log(chalk.green('\n✅ Clone operation completed!'));
     console.log(chalk.yellow('💡 Commands:'));
     console.log(`  • ${chalk.cyan('hayai list')} - View all databases`);
     console.log(`  • ${chalk.cyan('hayai studio')} - Open admin dashboards`);
   } catch (error) {
-    spinner.fail('Clone operation failed');
+    spinner?.fail('Clone operation failed');
     await recordOperation({
       operation: 'clone',
       source: options.from,
@@ -380,8 +431,7 @@ async function handleClone(options: CloneOptions): Promise<void> {
       success: false,
       error: error instanceof Error ? error.message : String(error),
     });
-    console.error(chalk.red('\n❌ Clone failed:'), error instanceof Error ? error.message : error);
-    process.exit(1);
+    failFromError('clone', error, jsonMode);
   }
 }
 
@@ -394,6 +444,7 @@ export const cloneCommand = new Command('clone')
   .option('--force', 'Overwrite existing target databases')
   .option('--dry-run', 'Show what would be cloned without executing')
   .option('--verbose', 'Enable verbose output')
+  .option('--json', 'Machine-readable JSON output on stdout (implies non-interactive)')
   .addHelpText(
     'after',
     `

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { getDockerManager } from '../../core/docker.js';
 import { buildConnectionInfo } from '../../core/connection.js';
+import { ExitCode, fail, failFromError } from '../cli-output.js';
 
 export const connectCommand = new Command('connect')
   .description('Print connection details for a database instance')
@@ -29,9 +30,15 @@ ${chalk.bold('Examples:')}
 
       const instance = dockerManager.getInstance(name);
       if (!instance) {
-        console.error(chalk.red(`❌ Database instance '${name}' not found`));
-        console.log(chalk.yellow('💡 Run `hayai list` to see available databases'));
-        process.exit(1);
+        // connect --json intentionally prints the raw ConnectionInfo object
+        // (documented in AUTOMATION.md), so failures stay on stderr here.
+        fail(
+          'connect',
+          ExitCode.NotFound,
+          `Database instance '${name}' not found`,
+          false,
+          'Run `hayai list` to see available databases',
+        );
       }
 
       const info = buildConnectionInfo(instance);
@@ -55,10 +62,6 @@ ${chalk.bold('Examples:')}
         chalk.gray('\n💡 Script-friendly: ') + chalk.cyan(`hayai connect ${info.name} --uri`),
       );
     } catch (error) {
-      console.error(
-        chalk.red('\n❌ Failed to read connection details:'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('connect', error, false);
     }
   });

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -2,18 +2,26 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import { HayaiDbManager } from '../../core/hayaidb.js';
+import { failFromError, succeed } from '../cli-output.js';
 
 async function exportHandler(options: {
   output?: string;
   format?: string;
   verbose?: boolean;
+  json?: boolean;
 }): Promise<void> {
-  const spinner = ora('Exporting database configuration...').start();
+  const jsonMode = Boolean(options.json);
+  const spinner = jsonMode ? null : ora('Exporting database configuration...').start();
 
   try {
     const outputPath = await HayaiDbManager.exportConfig(options.output);
 
-    spinner.succeed(`Configuration exported to ${chalk.green(outputPath)}`);
+    spinner?.succeed(`Configuration exported to ${chalk.green(outputPath)}`);
+
+    if (jsonMode) {
+      succeed('export', { file: outputPath }, jsonMode);
+      return;
+    }
 
     console.log('\n📄 Configuration file created!');
     console.log(`   ${chalk.cyan('File:')} ${outputPath}`);
@@ -25,19 +33,11 @@ async function exportHandler(options: {
       console.log('   • Use `hayai sync` to recreate databases from this file');
     }
   } catch (error) {
-    spinner.fail('Failed to export configuration');
-
-    if (error instanceof Error) {
-      console.error(`\n❌ ${chalk.red('Error:')} ${error.message}`);
-    } else {
-      console.error(`\n❌ ${chalk.red('Unexpected error occurred')}`);
-    }
-
-    if (options.verbose) {
+    spinner?.fail('Failed to export configuration');
+    if (options.verbose && !jsonMode) {
       console.error('\n📋 Details:', error);
     }
-
-    process.exit(1);
+    failFromError('export', error, jsonMode);
   }
 }
 
@@ -46,4 +46,5 @@ export const exportCommand = new Command('export')
   .option('-o, --output <path>', 'Output file path (default: .hayaidb)')
   .option('-f, --format <format>', 'Output format (yaml)', 'yaml')
   .option('--verbose', 'Enable verbose output')
+  .option('--json', 'Machine-readable JSON output on stdout')
   .action(exportHandler);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -3,8 +3,9 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
 import { getTemplate, getAvailableTypes, getEnginesByType } from '../../core/templates.js';
-import { createDatabase } from '../../core/docker.js';
+import { createDatabase, getDockerManager } from '../../core/docker.js';
 import { InitOptions } from '../../core/types.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 // Map technical types to user-friendly display names
 const getDisplayName = (type: string): string => {
@@ -21,15 +22,35 @@ const getDisplayName = (type: string): string => {
   return displayNames[type] || type.toUpperCase();
 };
 
+interface InitCommandOptions extends InitOptions {
+  existsOk?: boolean;
+  json?: boolean;
+}
+
 export const initCommand = new Command('init')
   .description('Initialize a new database instance')
   .option('-n, --name <name>', 'Database instance name')
   .option('-e, --engine <engine>', 'Database engine (postgresql, mariadb, redis, etc.)')
   .option('-p, --port <port>', 'Custom port number', parseInt)
   .option('-y, --yes', 'Skip interactive prompts and use defaults')
-  .action(async (options: InitOptions) => {
+  .option(
+    '--exists-ok',
+    'Exit 0 without changes if an instance with this name and engine already exists',
+  )
+  .option('--json', 'Machine-readable JSON output on stdout (implies non-interactive)')
+  .action(async (options: InitCommandOptions) => {
+    const jsonMode = Boolean(options.json);
     try {
-      const spinner = ora('Initializing database...').start();
+      // --json is a promise to never block on a prompt: with the required
+      // inputs missing there is nothing valid to do but refuse.
+      if (jsonMode && (!options.name || !options.engine)) {
+        fail(
+          'init',
+          ExitCode.Usage,
+          '--json requires --name and --engine (prompts are disabled)',
+          jsonMode,
+        );
+      }
 
       let config: {
         name: string;
@@ -37,17 +58,15 @@ export const initCommand = new Command('init')
         port?: number;
       };
 
-      if (options.yes && options.name && options.engine) {
+      if ((options.yes || jsonMode) && options.name && options.engine) {
         // Non-interactive mode
         config = {
           name: options.name,
           engine: options.engine,
           port: options.port,
         };
-        spinner.stop();
       } else {
         // Interactive mode
-        spinner.stop();
         console.log(chalk.cyan("\n🚀 Let's set up your database!\n"));
 
         const availableTypes = getAvailableTypes();
@@ -121,10 +140,43 @@ export const initCommand = new Command('init')
       // Get the database template
       const template = getTemplate(config.engine);
       if (!template) {
-        throw new Error(`Database engine '${config.engine}' is not supported`);
+        fail(
+          'init',
+          ExitCode.Usage,
+          `Database engine '${config.engine}' is not supported`,
+          jsonMode,
+          'Run `hayai init` without flags to browse the supported engines',
+        );
       }
 
-      if (template.experimental) {
+      // Idempotency: an orchestrator retry must not explode on its own success.
+      const dockerManager = getDockerManager();
+      await dockerManager.initialize();
+      const existing = dockerManager.getInstance(config.name);
+      if (existing) {
+        if (options.existsOk && existing.engine === config.engine) {
+          if (!jsonMode) {
+            console.log(
+              chalk.gray(`ℹ️  Instance '${config.name}' (${existing.engine}) already exists — ok`),
+            );
+          }
+          succeed('init', { created: false, instance: existing }, jsonMode);
+          return;
+        }
+        const detail =
+          existing.engine === config.engine
+            ? `Instance '${config.name}' already exists`
+            : `Instance '${config.name}' already exists with a different engine (${existing.engine})`;
+        fail(
+          'init',
+          ExitCode.Conflict,
+          detail,
+          jsonMode,
+          options.existsOk ? undefined : 'Use --exists-ok for idempotent creation',
+        );
+      }
+
+      if (template.experimental && !jsonMode) {
         console.log(
           chalk.yellow(
             `\n⚠️  ${template.name} is experimental: hayai runs it as a single container, but it needs a multi-node cluster to work properly. Expect it to be partially or non-functional.`,
@@ -133,13 +185,42 @@ export const initCommand = new Command('init')
       }
 
       // Create the database instance
-      const createSpinner = ora(`Creating ${template.name} instance '${config.name}'...`).start();
+      const createSpinner = jsonMode
+        ? null
+        : ora(`Creating ${template.name} instance '${config.name}'...`).start();
 
-      const instance = await createDatabase(config.name, template, {
-        port: config.port,
-      });
+      let instance;
+      try {
+        instance = await createDatabase(config.name, template, {
+          port: config.port,
+        });
+      } catch (error) {
+        createSpinner?.fail(`Failed to create '${config.name}'`);
+        // A concurrent process may have created the same name between our
+        // check and the locked create — map that race to the same contract.
+        if (error instanceof Error && error.message.includes('already exists')) {
+          if (options.existsOk) {
+            const raced = getDockerManager().getInstance(config.name);
+            if (raced && raced.engine === config.engine) {
+              succeed('init', { created: false, instance: raced }, jsonMode);
+              return;
+            }
+          }
+          fail('init', ExitCode.Conflict, error.message, jsonMode);
+        }
+        throw error;
+      }
 
-      createSpinner.succeed(`Successfully created ${template.name} instance '${config.name}'`);
+      createSpinner?.succeed(`Successfully created ${template.name} instance '${config.name}'`);
+
+      if (jsonMode) {
+        succeed(
+          'init',
+          { created: true, instance, experimental: Boolean(template.experimental) },
+          jsonMode,
+        );
+        return;
+      }
 
       // Display success information
       console.log(chalk.green('\n✅ Database instance created successfully!\n'));
@@ -161,10 +242,6 @@ export const initCommand = new Command('init')
       console.log(`  2. Run ${chalk.cyan('hayai list')} to see all your databases`);
       console.log(`  3. Run ${chalk.cyan('hayai studio')} to open admin dashboards`);
     } catch (error) {
-      console.error(
-        chalk.red('\n❌ Failed to initialize database:'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('init', error, jsonMode);
     }
   });

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -2,12 +2,14 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { getDockerManager } from '../../core/docker.js';
 import { getTemplate } from '../../core/templates.js';
+import { failFromError, succeed } from '../cli-output.js';
 
 export const listCommand = new Command('list')
   .description('List all database instances')
   .option('-r, --running', 'Show only running instances')
   .option('-s, --stopped', 'Show only stopped instances')
   .option('--format <format>', 'Output format (table, json)', 'table')
+  .option('--json', 'Machine-readable JSON envelope on stdout (see AUTOMATION.md)')
   .action(async (options) => {
     try {
       const dockerManager = getDockerManager();
@@ -19,6 +21,13 @@ export const listCommand = new Command('list')
         instances = dockerManager.getRunningInstances();
       } else if (options.stopped) {
         instances = dockerManager.getStoppedInstances();
+      }
+
+      // Envelope form of the contract; --format json stays as the raw-array
+      // shape it has always emitted.
+      if (options.json) {
+        succeed('list', { instances }, true);
+        return;
       }
 
       if (instances.length === 0) {
@@ -94,10 +103,6 @@ export const listCommand = new Command('list')
       console.log('  • hayai remove <name> - Remove a database');
       console.log('  • hayai studio        - Open admin dashboards');
     } catch (error) {
-      console.error(
-        chalk.red('\n❌ Failed to list databases:'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('list', error, Boolean(options.json));
     }
   });

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -9,6 +9,7 @@ import { recordOperation } from '../../core/security.js';
 import { snapshotInstance } from './snapshot.js';
 import { CLIOptions } from '../../core/types.js';
 import { spawn } from 'child_process';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 // Engines with a real, key/row-level merge. Anything else (or a cross-engine
 // pair) is refused rather than guessed at.
@@ -21,6 +22,7 @@ interface MergeOptions extends CLIOptions {
   execute?: boolean;
   backupBoth?: boolean;
   force?: boolean;
+  json?: boolean;
 }
 
 async function previewMerge(sourceInstance: any, targetInstance: any): Promise<void> {
@@ -313,64 +315,98 @@ async function migrateRedisKey(
 }
 
 async function handleMerge(options: MergeOptions): Promise<void> {
+  const jsonMode = Boolean(options.json);
   const dockerManager = getDockerManager();
   await dockerManager.initialize();
 
   // Validate source database
   const sourceInstance = dockerManager.getInstance(options.source);
   if (!sourceInstance) {
-    console.error(chalk.red(`❌ Source database '${options.source}' not found`));
-    process.exit(1);
+    fail('merge', ExitCode.NotFound, `Source database '${options.source}' not found`, jsonMode);
   }
 
   // Validate target database
   const targetInstance = dockerManager.getInstance(options.target);
   if (!targetInstance) {
-    console.error(chalk.red(`❌ Target database '${options.target}' not found`));
-    process.exit(1);
+    fail('merge', ExitCode.NotFound, `Target database '${options.target}' not found`, jsonMode);
   }
 
   // Check if both databases are running
   if (sourceInstance.status !== 'running') {
-    console.error(chalk.red(`❌ Source database '${options.source}' must be running`));
-    console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${options.source}`)}`));
-    process.exit(1);
+    fail(
+      'merge',
+      ExitCode.Precondition,
+      `Source database '${options.source}' must be running`,
+      jsonMode,
+      `Start it with: hayai start ${options.source}`,
+    );
   }
 
   if (targetInstance.status !== 'running') {
-    console.error(chalk.red(`❌ Target database '${options.target}' must be running`));
-    console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${options.target}`)}`));
-    process.exit(1);
+    fail(
+      'merge',
+      ExitCode.Precondition,
+      `Target database '${options.target}' must be running`,
+      jsonMode,
+      `Start it with: hayai start ${options.target}`,
+    );
   }
 
   // Merge stays inside one engine family and only where a real row/key-level
   // merge exists. Cross-engine or unsupported pairs are refused — the previous
   // file-level fallback silently corrupted the target.
   if (sourceInstance.engine !== targetInstance.engine) {
-    console.error(
-      chalk.red(
-        `❌ Cannot merge across engines: ${sourceInstance.engine} → ${targetInstance.engine}`,
-      ),
+    fail(
+      'merge',
+      ExitCode.Precondition,
+      `Cannot merge across engines: ${sourceInstance.engine} → ${targetInstance.engine}`,
+      jsonMode,
+      'Source and target must run the same engine',
     );
-    console.log(chalk.yellow('💡 Source and target must run the same engine'));
-    process.exit(1);
   }
   if (!MERGEABLE_ENGINES.has(sourceInstance.engine)) {
-    console.error(chalk.red(`❌ Merge is not supported for '${sourceInstance.engine}'`));
-    console.log(chalk.yellow(`💡 Supported engines: ${[...MERGEABLE_ENGINES].join(', ')}`));
-    process.exit(1);
+    fail(
+      'merge',
+      ExitCode.Precondition,
+      `Merge is not supported for '${sourceInstance.engine}'`,
+      jsonMode,
+      `Supported engines: ${[...MERGEABLE_ENGINES].join(', ')}`,
+    );
   }
 
   // Preview mode: explicit --preview, or any invocation without --execute.
   // --force never substitutes for --execute; it only skips the confirmation.
   if (options.preview || !options.execute) {
+    if (jsonMode) {
+      succeed(
+        'merge',
+        {
+          executed: false,
+          preview: true,
+          source: options.source,
+          target: options.target,
+          engine: sourceInstance.engine,
+        },
+        jsonMode,
+      );
+      return;
+    }
     await previewMerge(sourceInstance, targetInstance);
     console.log(chalk.cyan('\n💡 Use --execute to perform the merge operation'));
     return;
   }
 
-  // Final confirmation for destructive operation
+  // Final confirmation for destructive operation. --json promises
+  // non-interactivity: refuse instead of hanging on a prompt.
   if (!options.force) {
+    if (jsonMode) {
+      fail(
+        'merge',
+        ExitCode.Precondition,
+        'Merge requires confirmation: pass --force with --json',
+        jsonMode,
+      );
+    }
     const { proceed } = await inquirer.prompt([
       {
         type: 'confirm',
@@ -388,34 +424,56 @@ async function handleMerge(options: MergeOptions): Promise<void> {
 
   // Safety snapshots of both sides before an irreversible merge. A failed
   // backup aborts the merge — the whole point is to not proceed unprotected.
+  const backups: { source?: string; target?: string } = {};
   if (options.backupBoth) {
-    const backupSpinner = ora('Backing up both databases...').start();
+    const backupSpinner = jsonMode ? null : ora('Backing up both databases...').start();
     try {
-      const sourceBackup = await snapshotInstance(sourceInstance);
-      const targetBackup = await snapshotInstance(targetInstance);
-      backupSpinner.succeed('Safety snapshots created');
-      console.log(chalk.gray(`  source → ${sourceBackup}`));
-      console.log(chalk.gray(`  target → ${targetBackup}`));
+      backups.source = await snapshotInstance(sourceInstance);
+      backups.target = await snapshotInstance(targetInstance);
+      backupSpinner?.succeed('Safety snapshots created');
+      if (!jsonMode) {
+        console.log(chalk.gray(`  source → ${backups.source}`));
+        console.log(chalk.gray(`  target → ${backups.target}`));
+      }
     } catch (error) {
-      backupSpinner.fail('Backup failed — aborting merge');
-      console.error(chalk.red('❌'), error instanceof Error ? error.message : error);
-      process.exit(1);
+      backupSpinner?.fail('Backup failed — aborting merge');
+      fail(
+        'merge',
+        ExitCode.Error,
+        `Safety backup failed, merge aborted: ${error instanceof Error ? error.message : error}`,
+        jsonMode,
+      );
     }
   }
 
   // Execute merge
-  const spinner = ora('Merging databases...').start();
+  const spinner = jsonMode ? null : ora('Merging databases...').start();
 
   try {
     await mergeDatabases(sourceInstance, targetInstance);
 
-    spinner.succeed('Database merge completed successfully');
+    spinner?.succeed('Database merge completed successfully');
     await recordOperation({
       operation: 'merge',
       source: options.source,
       target: options.target,
       success: true,
     });
+
+    if (jsonMode) {
+      succeed(
+        'merge',
+        {
+          executed: true,
+          source: options.source,
+          target: options.target,
+          engine: sourceInstance.engine,
+          backups: options.backupBoth ? backups : undefined,
+        },
+        jsonMode,
+      );
+      return;
+    }
 
     console.log(chalk.green('\n✅ Merge operation completed!'));
     console.log(
@@ -427,7 +485,7 @@ async function handleMerge(options: MergeOptions): Promise<void> {
     console.log(`  • ${chalk.cyan('hayai list')} - View all databases`);
     console.log(`  • ${chalk.cyan('hayai studio')} - Open admin dashboards`);
   } catch (error) {
-    spinner.fail('Merge operation failed');
+    spinner?.fail('Merge operation failed');
     await recordOperation({
       operation: 'merge',
       source: options.source,
@@ -435,8 +493,7 @@ async function handleMerge(options: MergeOptions): Promise<void> {
       success: false,
       error: error instanceof Error ? error.message : String(error),
     });
-    console.error(chalk.red('\n❌ Merge failed:'), error instanceof Error ? error.message : error);
-    process.exit(1);
+    failFromError('merge', error, jsonMode);
   }
 }
 
@@ -449,6 +506,7 @@ export const mergeCommand = new Command('merge')
   .option('--backup-both', 'Create backups of both databases before merging')
   .option('--force', 'Skip confirmation prompts')
   .option('--verbose', 'Enable verbose output')
+  .option('--json', 'Machine-readable JSON output on stdout (implies non-interactive)')
   .addHelpText(
     'after',
     `

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -4,25 +4,59 @@ import inquirer from 'inquirer';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
 import { recordOperation } from '../../core/security.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
+
+interface RemoveCommandOptions {
+  force?: boolean;
+  keepData?: boolean;
+  missingOk?: boolean;
+  json?: boolean;
+}
 
 export const removeCommand = new Command('remove')
   .description('Remove a database instance')
   .argument('<name>', 'Database instance name')
   .option('-f, --force', 'Force removal without confirmation')
   .option('--keep-data', 'Keep the data volume')
-  .action(async (name: string, options) => {
+  .option('--missing-ok', 'Exit 0 without changes if the instance does not exist')
+  .option('--json', 'Machine-readable JSON output on stdout (implies non-interactive)')
+  .action(async (name: string, options: RemoveCommandOptions) => {
+    const jsonMode = Boolean(options.json);
     try {
       const dockerManager = getDockerManager();
       await dockerManager.initialize();
 
       const instance = dockerManager.getInstance(name);
       if (!instance) {
-        console.error(chalk.red(`❌ Database instance '${name}' not found`));
-        process.exit(1);
+        // Idempotency: a retried teardown that finds nothing to tear down
+        // has succeeded, not failed.
+        if (options.missingOk) {
+          if (!jsonMode) {
+            console.log(chalk.gray(`ℹ️  Instance '${name}' does not exist — ok`));
+          }
+          succeed('remove', { removed: false, name }, jsonMode);
+          return;
+        }
+        fail(
+          'remove',
+          ExitCode.NotFound,
+          `Database instance '${name}' not found`,
+          jsonMode,
+          'Use --missing-ok for idempotent removal',
+        );
       }
 
-      // Confirmation prompt
+      // Confirmation prompt. --json promises non-interactivity, so without
+      // --force it refuses instead of hanging an orchestrator on a prompt.
       if (!options.force) {
+        if (jsonMode) {
+          fail(
+            'remove',
+            ExitCode.Precondition,
+            'Removal requires confirmation: pass --force with --json',
+            jsonMode,
+          );
+        }
         const { confirm } = await inquirer.prompt([
           {
             type: 'confirm',
@@ -38,11 +72,11 @@ export const removeCommand = new Command('remove')
         }
       }
 
-      const spinner = ora(`Removing database '${name}'...`).start();
+      const spinner = jsonMode ? null : ora(`Removing database '${name}'...`).start();
 
       // Stop the database if it's running
       if (instance.status === 'running') {
-        spinner.text = `Stopping database '${name}'...`;
+        if (spinner) spinner.text = `Stopping database '${name}'...`;
         await dockerManager.stopDatabase(name);
       }
 
@@ -50,7 +84,12 @@ export const removeCommand = new Command('remove')
       await dockerManager.removeDatabase(name, { keepData: options.keepData });
       await recordOperation({ operation: 'remove', source: name, success: true });
 
-      spinner.succeed(`Database '${name}' removed successfully`);
+      spinner?.succeed(`Database '${name}' removed successfully`);
+
+      if (jsonMode) {
+        succeed('remove', { removed: true, name, dataKept: Boolean(options.keepData) }, jsonMode);
+        return;
+      }
 
       console.log(chalk.green('\n✅ Database removed!'));
       if (options.keepData) {
@@ -64,10 +103,6 @@ export const removeCommand = new Command('remove')
         success: false,
         error: error instanceof Error ? error.message : String(error),
       });
-      console.error(
-        chalk.red('\n❌ Failed to remove database:'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('remove', error, jsonMode);
     }
   });

--- a/src/cli/commands/restore.ts
+++ b/src/cli/commands/restore.ts
@@ -11,12 +11,14 @@ import { resolveServiceContainer } from '../../core/containers.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { recordOperation } from '../../core/security.js';
 import { DatabaseInstance } from '../../core/types.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 interface RestoreOptions {
   to?: string;
   force?: boolean;
   confirm?: boolean;
   verbose?: boolean;
+  json?: boolean;
 }
 
 const EMBEDDED_ENGINES = new Set(['sqlite', 'duckdb', 'leveldb', 'lmdb']);
@@ -183,13 +185,19 @@ async function resolveSnapshotPath(input: string): Promise<string> {
 }
 
 async function handleRestore(snapshot: string, options: RestoreOptions): Promise<void> {
+  const jsonMode = Boolean(options.json);
+
   let snapshotPath: string;
   try {
     snapshotPath = await resolveSnapshotPath(snapshot);
   } catch (error) {
-    console.error(chalk.red(`❌ ${error instanceof Error ? error.message : error}`));
-    console.log(chalk.yellow('💡 List snapshots with: ') + chalk.cyan('hayai snapshot list'));
-    process.exit(1);
+    fail(
+      'restore',
+      ExitCode.NotFound,
+      error instanceof Error ? error.message : String(error),
+      jsonMode,
+      'List snapshots with: hayai snapshot list',
+    );
   }
 
   // The snapshot filename encodes the source instance: <name>-snapshot-<ts>.<ext>
@@ -201,29 +209,54 @@ async function handleRestore(snapshot: string, options: RestoreOptions): Promise
 
   const instance = dockerManager.getInstance(targetName);
   if (!instance) {
-    console.error(chalk.red(`❌ Target database '${targetName}' not found`));
-    console.log(chalk.yellow('💡 Pass an existing instance with --to, or run `hayai list`'));
-    process.exit(1);
+    fail(
+      'restore',
+      ExitCode.NotFound,
+      `Target database '${targetName}' not found`,
+      jsonMode,
+      'Pass an existing instance with --to, or run `hayai list`',
+    );
   }
 
   if (!RESTORABLE_ENGINES.has(instance.engine)) {
-    console.error(chalk.red(`❌ Restore is not supported for '${instance.engine}'`));
-    showManualRestoreGuidance(instance.engine);
-    process.exit(1);
+    if (!jsonMode) {
+      showManualRestoreGuidance(instance.engine);
+    }
+    fail(
+      'restore',
+      ExitCode.Precondition,
+      `Restore is not supported for '${instance.engine}'`,
+      jsonMode,
+    );
   }
 
   if (instance.status !== 'running' && instance.status !== 'embedded') {
-    console.error(chalk.red(`❌ Target '${targetName}' must be running to restore into it`));
-    console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${targetName}`)}`));
-    process.exit(1);
+    fail(
+      'restore',
+      ExitCode.Precondition,
+      `Target '${targetName}' must be running to restore into it`,
+      jsonMode,
+      `Start it with: hayai start ${targetName}`,
+    );
   }
 
-  console.log(chalk.cyan('\n🔁 Restore Plan:'));
-  console.log(chalk.gray(`Snapshot: ${snapshotPath}`));
-  console.log(chalk.gray(`Target:   ${targetName} (${instance.engine})`));
-  console.log(chalk.yellow('\n⚠️  This overwrites the data currently in the target.'));
+  if (!jsonMode) {
+    console.log(chalk.cyan('\n🔁 Restore Plan:'));
+    console.log(chalk.gray(`Snapshot: ${snapshotPath}`));
+    console.log(chalk.gray(`Target:   ${targetName} (${instance.engine})`));
+    console.log(chalk.yellow('\n⚠️  This overwrites the data currently in the target.'));
+  }
 
   if (!options.confirm && !options.force) {
+    // --json promises non-interactivity: refuse instead of hanging on a prompt.
+    if (jsonMode) {
+      fail(
+        'restore',
+        ExitCode.Precondition,
+        'Restore requires confirmation: pass --force or -y with --json',
+        jsonMode,
+      );
+    }
     const { proceed } = await inquirer.prompt([
       {
         type: 'confirm',
@@ -238,10 +271,10 @@ async function handleRestore(snapshot: string, options: RestoreOptions): Promise
     }
   }
 
-  const spinner = ora(`Restoring into '${targetName}'...`).start();
+  const spinner = jsonMode ? null : ora(`Restoring into '${targetName}'...`).start();
   try {
     await restoreInto(instance, snapshotPath);
-    spinner.succeed(`Restored '${targetName}' from snapshot`);
+    spinner?.succeed(`Restored '${targetName}' from snapshot`);
     await recordOperation({
       operation: 'restore',
       source: path.basename(snapshotPath),
@@ -249,10 +282,19 @@ async function handleRestore(snapshot: string, options: RestoreOptions): Promise
       success: true,
     });
 
+    if (jsonMode) {
+      succeed(
+        'restore',
+        { target: targetName, engine: instance.engine, snapshot: snapshotPath },
+        jsonMode,
+      );
+      return;
+    }
+
     console.log(chalk.green('\n✅ Restore completed!'));
     console.log(chalk.yellow('💡 Verify with: ') + chalk.cyan('hayai studio'));
   } catch (error) {
-    spinner.fail('Restore failed');
+    spinner?.fail('Restore failed');
     await recordOperation({
       operation: 'restore',
       source: path.basename(snapshotPath),
@@ -260,11 +302,7 @@ async function handleRestore(snapshot: string, options: RestoreOptions): Promise
       success: false,
       error: error instanceof Error ? error.message : String(error),
     });
-    console.error(
-      chalk.red('\n❌ Restore failed:'),
-      error instanceof Error ? error.message : error,
-    );
-    process.exit(1);
+    failFromError('restore', error, jsonMode);
   }
 }
 
@@ -275,6 +313,7 @@ export const restoreCommand = new Command('restore')
   .option('-y, --confirm', 'Skip the confirmation prompt')
   .option('--force', 'Skip the confirmation prompt')
   .option('--verbose', 'Enable verbose output')
+  .option('--json', 'Machine-readable JSON output on stdout (implies non-interactive)')
   .addHelpText(
     'after',
     `

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -11,6 +11,7 @@ import { getTemplate } from '../../core/templates.js';
 import { getPostgresExecCredentials, getMariaDBRootPassword } from '../../core/credentials.js';
 import { recordOperation } from '../../core/security.js';
 import { DatabaseInstance, SnapshotOptions } from '../../core/types.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 async function createSnapshotDirectory(dir: string): Promise<void> {
   try {
@@ -313,36 +314,48 @@ export const snapshotCommand = new Command('snapshot')
   .description('Create snapshots of database instances')
   .argument('<name>', 'Database instance name')
   .option('-o, --output <path>', 'Output directory for snapshots', './snapshots')
-  .action(async (name: string, options: SnapshotOptions) => {
+  .option('--json', 'Machine-readable JSON output on stdout')
+  .action(async (name: string, options: SnapshotOptions & { json?: boolean }) => {
+    const jsonMode = Boolean(options.json);
     try {
       const dockerManager = getDockerManager();
       await dockerManager.initialize();
 
       const instance = dockerManager.getInstance(name);
       if (!instance) {
-        console.error(chalk.red(`❌ Database instance '${name}' not found`));
-        console.log(chalk.yellow('💡 Run `hayai list` to see available databases'));
-        process.exit(1);
+        fail(
+          'snapshot',
+          ExitCode.NotFound,
+          `Database instance '${name}' not found`,
+          jsonMode,
+          'Run `hayai list` to see available databases',
+        );
       }
 
       if (instance.status !== 'running' && instance.status !== 'embedded') {
-        console.error(chalk.red(`❌ Database '${name}' must be running to create snapshot`));
-        console.log(chalk.yellow(`💡 Start it with: ${chalk.cyan(`hayai start ${name}`)}`));
-        process.exit(1);
+        fail(
+          'snapshot',
+          ExitCode.Precondition,
+          `Database '${name}' must be running to create snapshot`,
+          jsonMode,
+          `Start it with: hayai start ${name}`,
+        );
       }
 
       const outputDir = options.output || './snapshots';
 
-      console.log(chalk.cyan(`📸 Creating snapshot of '${name}'...`));
-      console.log(chalk.gray(`Engine: ${instance.engine}`));
+      if (!jsonMode) {
+        console.log(chalk.cyan(`📸 Creating snapshot of '${name}'...`));
+        console.log(chalk.gray(`Engine: ${instance.engine}`));
+      }
 
-      const spinner = ora('Creating snapshot...').start();
+      const spinner = jsonMode ? null : ora('Creating snapshot...').start();
 
       let snapshotPath: string;
       try {
         snapshotPath = await snapshotInstance(instance, outputDir);
       } catch (error) {
-        spinner.fail('Snapshot failed');
+        spinner?.fail('Snapshot failed');
         await recordOperation({
           operation: 'snapshot',
           source: name,
@@ -355,13 +368,27 @@ export const snapshotCommand = new Command('snapshot')
       const stats = await fs.stat(snapshotPath);
       const fileSizeMB = (stats.size / (1024 * 1024)).toFixed(2);
 
-      spinner.succeed(`Snapshot created successfully (${fileSizeMB} MB)`);
+      spinner?.succeed(`Snapshot created successfully (${fileSizeMB} MB)`);
       await recordOperation({
         operation: 'snapshot',
         source: name,
         target: snapshotPath,
         success: true,
       });
+
+      if (jsonMode) {
+        succeed(
+          'snapshot',
+          {
+            source: name,
+            engine: instance.engine,
+            snapshot: snapshotPath,
+            sizeMB: Number(fileSizeMB),
+          },
+          jsonMode,
+        );
+        return;
+      }
 
       console.log(chalk.gray(`Output: ${snapshotPath}`));
       console.log(chalk.green('\n✅ Snapshot completed!'));
@@ -371,11 +398,7 @@ export const snapshotCommand = new Command('snapshot')
         `  • ${chalk.cyan(`hayai restore ${path.basename(snapshotPath)}`)} - Restore this snapshot`,
       );
     } catch (error) {
-      console.error(
-        chalk.red('❌ Snapshot failed:'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('snapshot', error, jsonMode);
     }
   });
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -2,36 +2,60 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 export const startCommand = new Command('start')
   .description('Start database instances')
   .argument('[name]', 'Database instance name (optional, starts all if not specified)')
-  .option('-a, --all', 'Start all database instances')
-  .action(async (name: string) => {
+  .option('-a, --all', 'Start all database instances (explicit form of omitting the name)')
+  .option('--json', 'Machine-readable JSON output on stdout')
+  .action(async (name: string, options: { all?: boolean; json?: boolean }) => {
+    const jsonMode = Boolean(options.json);
     try {
+      if (name && options.all) {
+        fail('start', ExitCode.Usage, 'Pass a name or --all, not both', jsonMode);
+      }
+
       const dockerManager = getDockerManager();
       await dockerManager.initialize();
 
       if (name) {
-        // Start specific database
-        const spinner = ora(`Starting database '${name}'...`).start();
+        if (!dockerManager.getInstance(name)) {
+          fail(
+            'start',
+            ExitCode.NotFound,
+            `Database instance '${name}' not found`,
+            jsonMode,
+            'Run `hayai list` to see available databases',
+          );
+        }
+
+        const spinner = jsonMode ? null : ora(`Starting database '${name}'...`).start();
         await dockerManager.startDatabase(name);
-        spinner.succeed(`Database '${name}' started successfully`);
+        spinner?.succeed(`Database '${name}' started successfully`);
+        succeed('start', { started: [name] }, jsonMode);
       } else {
-        // Start all databases
-        const spinner = ora('Starting all databases...').start();
+        const spinner = jsonMode ? null : ora('Starting all databases...').start();
         await dockerManager.startAllDatabases();
-        spinner.succeed('All databases started successfully');
+        spinner?.succeed('All databases started successfully');
+        succeed(
+          'start',
+          {
+            started: dockerManager
+              .getAllInstances()
+              .filter((instance) => instance.status === 'running')
+              .map((instance) => instance.name),
+          },
+          jsonMode,
+        );
       }
 
-      console.log(chalk.green('\n✅ Database(s) started!'));
-      console.log(chalk.yellow('💡 Run `hayai list` to see running instances'));
-      console.log(chalk.yellow('💡 Run `hayai studio` to open admin dashboards'));
+      if (!jsonMode) {
+        console.log(chalk.green('\n✅ Database(s) started!'));
+        console.log(chalk.yellow('💡 Run `hayai list` to see running instances'));
+        console.log(chalk.yellow('💡 Run `hayai studio` to open admin dashboards'));
+      }
     } catch (error) {
-      console.error(
-        chalk.red('\n❌ Failed to start database(s):'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('start', error, jsonMode);
     }
   });

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -2,35 +2,59 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getDockerManager } from '../../core/docker.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 export const stopCommand = new Command('stop')
   .description('Stop database instances')
   .argument('[name]', 'Database instance name (optional, stops all if not specified)')
-  .option('-a, --all', 'Stop all database instances')
-  .action(async (name: string) => {
+  .option('-a, --all', 'Stop all database instances (explicit form of omitting the name)')
+  .option('--json', 'Machine-readable JSON output on stdout')
+  .action(async (name: string, options: { all?: boolean; json?: boolean }) => {
+    const jsonMode = Boolean(options.json);
     try {
+      if (name && options.all) {
+        fail('stop', ExitCode.Usage, 'Pass a name or --all, not both', jsonMode);
+      }
+
       const dockerManager = getDockerManager();
       await dockerManager.initialize();
 
       if (name) {
-        // Stop specific database
-        const spinner = ora(`Stopping database '${name}'...`).start();
+        if (!dockerManager.getInstance(name)) {
+          fail(
+            'stop',
+            ExitCode.NotFound,
+            `Database instance '${name}' not found`,
+            jsonMode,
+            'Run `hayai list` to see available databases',
+          );
+        }
+
+        const spinner = jsonMode ? null : ora(`Stopping database '${name}'...`).start();
         await dockerManager.stopDatabase(name);
-        spinner.succeed(`Database '${name}' stopped successfully`);
+        spinner?.succeed(`Database '${name}' stopped successfully`);
+        succeed('stop', { stopped: [name] }, jsonMode);
       } else {
-        // Stop all databases
-        const spinner = ora('Stopping all databases...').start();
+        const spinner = jsonMode ? null : ora('Stopping all databases...').start();
         await dockerManager.stopAllDatabases();
-        spinner.succeed('All databases stopped successfully');
+        spinner?.succeed('All databases stopped successfully');
+        succeed(
+          'stop',
+          {
+            stopped: dockerManager
+              .getAllInstances()
+              .filter((instance) => instance.status === 'stopped')
+              .map((instance) => instance.name),
+          },
+          jsonMode,
+        );
       }
 
-      console.log(chalk.green('\n✅ Database(s) stopped!'));
-      console.log(chalk.yellow('💡 Run `hayai list` to see current status'));
+      if (!jsonMode) {
+        console.log(chalk.green('\n✅ Database(s) stopped!'));
+        console.log(chalk.yellow('💡 Run `hayai list` to see current status'));
+      }
     } catch (error) {
-      console.error(
-        chalk.red('\n❌ Failed to stop database(s):'),
-        error instanceof Error ? error.message : error,
-      );
-      process.exit(1);
+      failFromError('stop', error, jsonMode);
     }
   });

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -2,34 +2,54 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import { HayaiDbManager } from '../../core/hayaidb.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 async function syncHandler(options: {
   config?: string;
-  force?: boolean;
   dryRun?: boolean;
   verbose?: boolean;
+  json?: boolean;
 }): Promise<void> {
   const configPath = options.config || '.hayaidb';
+  const jsonMode = Boolean(options.json);
 
   // Check if config file exists
   if (!(await HayaiDbManager.configExists(configPath))) {
-    console.error(`❌ ${chalk.red('Configuration file not found:')} ${configPath}`);
-    console.log('\n💡 Generate one with:');
-    console.log(`   ${chalk.cyan('hayai export')}`);
-    process.exit(1);
+    fail(
+      'sync',
+      ExitCode.NotFound,
+      `Configuration file not found: ${configPath}`,
+      jsonMode,
+      'Generate one with: hayai export',
+    );
   }
 
-  const spinner = ora('Loading configuration...').start();
+  const spinner = jsonMode ? null : ora('Loading configuration...').start();
 
   try {
     // Load and validate config
     const config = await HayaiDbManager.loadConfig(configPath);
-    spinner.text = 'Validating configuration...';
+    if (spinner) spinner.text = 'Validating configuration...';
 
     const databaseCount = Object.keys(config.databases).length;
 
     if (options.dryRun) {
-      spinner.succeed(`Configuration is valid (${databaseCount} databases)`);
+      spinner?.succeed(`Configuration is valid (${databaseCount} databases)`);
+
+      if (jsonMode) {
+        succeed(
+          'sync',
+          {
+            dryRun: true,
+            project: config.project,
+            version: config.version,
+            databases: config.databases,
+            profiles: config.profiles,
+          },
+          jsonMode,
+        );
+        return;
+      }
 
       console.log(`\n📋 ${chalk.bold('Dry run - no databases will be created:')}`);
       console.log(`   ${chalk.cyan('Project:')} ${config.project || 'Unknown'}`);
@@ -52,10 +72,27 @@ async function syncHandler(options: {
     }
 
     // Sync databases
-    spinner.text = 'Synchronizing databases...';
+    if (spinner) spinner.text = 'Synchronizing databases...';
     const result = await HayaiDbManager.syncConfig(configPath);
 
-    spinner.succeed('Database synchronization completed!');
+    // Partial failure is a failure for the caller — some databases in the
+    // declared state do not exist. The envelope still carries what happened.
+    if (result.errors.length > 0) {
+      spinner?.fail(`Synchronization finished with ${result.errors.length} error(s)`);
+      if (!jsonMode) {
+        for (const error of result.errors) {
+          console.error(`   • ${chalk.red(error.name)}: ${error.error}`);
+        }
+      }
+      fail('sync', ExitCode.Error, `${result.errors.length} database(s) failed to sync`, jsonMode);
+    }
+
+    spinner?.succeed('Database synchronization completed!');
+
+    if (jsonMode) {
+      succeed('sync', { created: result.created, skipped: result.skipped }, jsonMode);
+      return;
+    }
 
     // Show results
     console.log(`\n📊 ${chalk.bold('Synchronization Results:')}`);
@@ -76,13 +113,6 @@ async function syncHandler(options: {
       }
     }
 
-    if (result.errors.length > 0) {
-      console.log(`\n❌ ${chalk.red('Errors:')} ${result.errors.length} databases failed`);
-      for (const error of result.errors) {
-        console.log(`   • ${chalk.red(error.name)}: ${error.error}`);
-      }
-    }
-
     // Next steps
     if (result.created.length > 0) {
       console.log('\n💡 Next steps:');
@@ -91,26 +121,20 @@ async function syncHandler(options: {
       console.log(`   • Run ${chalk.cyan('hayai studio')} to access admin dashboards`);
     }
   } catch (error) {
-    spinner.fail('Failed to synchronize databases');
-
-    if (error instanceof Error) {
-      console.error(`\n❌ ${chalk.red('Error:')} ${error.message}`);
-    } else {
-      console.error(`\n❌ ${chalk.red('Unexpected error occurred')}`);
-    }
-
-    if (options.verbose) {
+    spinner?.fail('Failed to synchronize databases');
+    if (options.verbose && !jsonMode) {
       console.error('\n📋 Details:', error);
     }
-
-    process.exit(1);
+    failFromError('sync', error, jsonMode);
   }
 }
 
 export const syncCommand = new Command('sync')
-  .description('Synchronize databases from .hayaidb configuration file')
+  .description(
+    'Synchronize databases from .hayaidb configuration file (additive: never modifies or removes existing instances)',
+  )
   .option('-c, --config <path>', 'Configuration file path (default: .hayaidb)')
   .option('--dry-run', 'Show what would be created without making changes')
-  .option('--force', 'Force creation even if databases exist')
   .option('--verbose', 'Enable verbose output')
+  .option('--json', 'Machine-readable JSON output on stdout')
   .action(syncHandler);

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import { DatabaseInstance, DatabaseTemplate, ComposeFile } from './types.js';
 import { getConfig, getComposeFilePath, getDataDirectory } from './config.js';
 import { allocatePort, deallocatePort } from './port-manager.js';
+import { withStateLock } from './lock.js';
 
 interface DockerVerificationResult {
   isInstalled: boolean;
@@ -14,6 +15,15 @@ interface DockerVerificationResult {
   composeAvailable?: boolean;
   version?: string;
   error?: string;
+}
+
+// Thrown instead of exiting so commands can map it to the documented
+// Environment exit code (and emit a JSON envelope in --json mode).
+export class DockerNotReadyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DockerNotReadyError';
+  }
 }
 
 export class DockerManager {
@@ -118,84 +128,87 @@ export class DockerManager {
   }
 
   private showDockerInstallationInstructions(result: DockerVerificationResult): void {
-    console.log(chalk.red('\n❌ Docker Setup Required\n'));
+    console.error(chalk.red('\n❌ Docker Setup Required\n'));
 
     if (!result.isInstalled) {
-      console.log(chalk.yellow('🐳 Docker is not installed on your system.'));
-      console.log(chalk.gray('Hayai requires Docker to manage database containers.\n'));
+      console.error(chalk.yellow('🐳 Docker is not installed on your system.'));
+      console.error(chalk.gray('Hayai requires Docker to manage database containers.\n'));
 
-      console.log(chalk.bold('📦 Installation Instructions:\n'));
+      console.error(chalk.bold('📦 Installation Instructions:\n'));
 
       const platform = process.platform;
 
       switch (platform) {
         case 'darwin': // macOS
-          console.log(chalk.cyan('macOS:'));
-          console.log(
+          console.error(chalk.cyan('macOS:'));
+          console.error(
             '  • Download Docker Desktop: https://docs.docker.com/desktop/install/mac-install/',
           );
-          console.log('  • Or install via Homebrew: brew install --cask docker');
+          console.error('  • Or install via Homebrew: brew install --cask docker');
           break;
 
         case 'win32': // Windows
-          console.log(chalk.cyan('Windows:'));
-          console.log(
+          console.error(chalk.cyan('Windows:'));
+          console.error(
             '  • Download Docker Desktop: https://docs.docker.com/desktop/install/windows-install/',
           );
-          console.log('  • Or install via Chocolatey: choco install docker-desktop');
-          console.log('  • Or install via Winget: winget install Docker.DockerDesktop');
+          console.error('  • Or install via Chocolatey: choco install docker-desktop');
+          console.error('  • Or install via Winget: winget install Docker.DockerDesktop');
           break;
 
         default: // Linux
-          console.log(chalk.cyan('Linux:'));
-          console.log('  • Ubuntu/Debian: curl -fsSL https://get.docker.com | sh');
-          console.log('  • Fedora: sudo dnf install docker-ce docker-ce-cli containerd.io');
-          console.log('  • Arch: sudo pacman -S docker docker-compose');
-          console.log(
+          console.error(chalk.cyan('Linux:'));
+          console.error('  • Ubuntu/Debian: curl -fsSL https://get.docker.com | sh');
+          console.error('  • Fedora: sudo dnf install docker-ce docker-ce-cli containerd.io');
+          console.error('  • Arch: sudo pacman -S docker docker-compose');
+          console.error(
             '  • Or use Docker Desktop: https://docs.docker.com/desktop/install/linux-install/',
           );
           break;
       }
     } else if (result.isRunning && result.composeAvailable === false) {
-      console.log(chalk.yellow('🐳 Docker is running but the Compose V2 plugin is missing.'));
-      console.log(chalk.gray(`Version: ${result.version}\n`));
+      console.error(chalk.yellow('🐳 Docker is running but the Compose V2 plugin is missing.'));
+      console.error(chalk.gray(`Version: ${result.version}\n`));
 
-      console.log(chalk.bold('📦 Install Docker Compose V2:\n'));
-      console.log(
+      console.error(chalk.bold('📦 Install Docker Compose V2:\n'));
+      console.error(
         chalk.cyan('  • Docker Desktop: update to a recent version (Compose V2 is included)'),
       );
-      console.log(chalk.cyan('  • Debian/Ubuntu: sudo apt-get install docker-compose-plugin'));
-      console.log(chalk.cyan('  • Other platforms: https://docs.docker.com/compose/install/'));
+      console.error(chalk.cyan('  • Debian/Ubuntu: sudo apt-get install docker-compose-plugin'));
+      console.error(chalk.cyan('  • Other platforms: https://docs.docker.com/compose/install/'));
     } else if (!result.isRunning) {
-      console.log(chalk.yellow('🐳 Docker is installed but not running.'));
-      console.log(chalk.gray(`Version: ${result.version}\n`));
+      console.error(chalk.yellow('🐳 Docker is installed but not running.'));
+      console.error(chalk.gray(`Version: ${result.version}\n`));
 
-      console.log(chalk.bold('🚀 Start Docker:\n'));
+      console.error(chalk.bold('🚀 Start Docker:\n'));
 
       const platform = process.platform;
 
       switch (platform) {
         case 'darwin': // macOS
         case 'win32': // Windows
-          console.log(chalk.cyan('• Start Docker Desktop application'));
-          console.log(chalk.cyan('• Wait for Docker to fully initialize'));
+          console.error(chalk.cyan('• Start Docker Desktop application'));
+          console.error(chalk.cyan('• Wait for Docker to fully initialize'));
           break;
 
         default: // Linux
-          console.log(chalk.cyan('• sudo systemctl start docker'));
-          console.log(chalk.cyan('• sudo systemctl enable docker  # Enable auto-start'));
-          console.log(chalk.cyan('• Or start Docker Desktop if installed'));
+          console.error(chalk.cyan('• sudo systemctl start docker'));
+          console.error(chalk.cyan('• sudo systemctl enable docker  # Enable auto-start'));
+          console.error(chalk.cyan('• Or start Docker Desktop if installed'));
           break;
       }
     }
 
-    console.log(
+    console.error(
       chalk.yellow('\n💡 After installing/starting Docker, try running your command again.'),
     );
-    console.log(chalk.gray('🔍 Verify Docker: docker --version && docker info\n'));
+    console.error(chalk.gray('🔍 Verify Docker: docker --version && docker info\n'));
   }
 
-  private async verifyDockerSetup(): Promise<void> {
+  // Verified lazily, only on the first operation that actually talks to the
+  // daemon. Embedded engines and read-only commands (list, connect, init)
+  // work without Docker at all.
+  public async ensureDockerReady(): Promise<void> {
     if (this.dockerVerified) {
       return; // Already verified in this session
     }
@@ -204,7 +217,7 @@ export class DockerManager {
 
     if (!result.isInstalled || !result.isRunning || !result.composeAvailable) {
       this.showDockerInstallationInstructions(result);
-      process.exit(1);
+      throw new DockerNotReadyError(result.error || 'Docker is not available');
     }
 
     // Docker is ready
@@ -225,11 +238,19 @@ export class DockerManager {
   }
 
   public async initialize(): Promise<void> {
-    // Verify Docker setup before doing anything else
-    await this.verifyDockerSetup();
-
     await this.loadExistingInstances();
     await this.loadComposeFile();
+  }
+
+  // All read-modify-write cycles over the local state go through here:
+  // reloading inside the lock is what makes concurrent hayai processes safe —
+  // without it, a stale in-memory map would overwrite the other process's
+  // changes on save.
+  private async mutateState<T>(fn: () => Promise<T>): Promise<T> {
+    return withStateLock(async () => {
+      await this.loadExistingInstances();
+      return await fn();
+    });
   }
 
   public async createDatabase(
@@ -241,49 +262,51 @@ export class DockerManager {
       customEnv?: Record<string, string>;
     } = {},
   ): Promise<DatabaseInstance> {
-    // Validate name
-    if (this.instances.has(name)) {
-      throw new Error(`Database instance '${name}' already exists`);
-    }
+    return this.mutateState(async () => {
+      // Validate name against the just-reloaded state, not a stale snapshot
+      if (this.instances.has(name)) {
+        throw new Error(`Database instance '${name}' already exists`);
+      }
 
-    // Embedded engines are plain files on the host — no container, no port
-    const isEmbedded = template.engine.ports.length === 0;
+      // Embedded engines are plain files on the host — no container, no port
+      const isEmbedded = template.engine.ports.length === 0;
 
-    let port = 0;
-    if (!isEmbedded && this.getDefaultPortForEngine(template.engine.name) > 0) {
-      port = await allocatePort(name, options.port);
-    }
+      let port = 0;
+      if (!isEmbedded && this.getDefaultPortForEngine(template.engine.name) > 0) {
+        port = await allocatePort(name, options.port);
+      }
 
-    // Create data directory
-    const dataDir = await getDataDirectory();
-    const instanceDataDir = path.join(dataDir, name);
-    await mkdir(instanceDataDir, { recursive: true });
+      // Create data directory
+      const dataDir = await getDataDirectory();
+      const instanceDataDir = path.join(dataDir, name);
+      await mkdir(instanceDataDir, { recursive: true });
 
-    // Create database instance
-    const instance: DatabaseInstance = {
-      name,
-      engine: template.engine.name,
-      port,
-      volume: instanceDataDir,
-      environment: {
-        ...template.engine.environment,
-        ...options.customEnv,
-      },
-      status: isEmbedded ? 'embedded' : 'stopped',
-      created_at: new Date().toISOString(),
-      connection_uri: this.generateConnectionUri(template, port, name, instanceDataDir),
-    };
+      // Create database instance
+      const instance: DatabaseInstance = {
+        name,
+        engine: template.engine.name,
+        port,
+        volume: instanceDataDir,
+        environment: {
+          ...template.engine.environment,
+          ...options.customEnv,
+        },
+        status: isEmbedded ? 'embedded' : 'stopped',
+        created_at: new Date().toISOString(),
+        connection_uri: this.generateConnectionUri(template, port, name, instanceDataDir),
+      };
 
-    // Add to instances
-    this.instances.set(name, instance);
+      // Add to instances
+      this.instances.set(name, instance);
 
-    // Update compose file
-    await this.updateComposeFile();
+      // Update compose file
+      await this.updateComposeFile();
 
-    // Save instances
-    await this.saveInstances();
+      // Save instances
+      await this.saveInstances();
 
-    return instance;
+      return instance;
+    });
   }
 
   public async removeDatabase(name: string, options: { keepData?: boolean } = {}): Promise<void> {
@@ -292,6 +315,8 @@ export class DockerManager {
       throw new Error(`Database instance '${name}' not found`);
     }
 
+    // Container teardown happens outside the state lock: a graceful stop can
+    // take many seconds and must not block concurrent hayai processes.
     if (instance.status !== 'embedded') {
       const serviceName = `${name}-db`;
 
@@ -304,22 +329,24 @@ export class DockerManager {
       }
     }
 
-    // Deallocate port if it was allocated
-    if (instance.port > 0) {
-      await deallocatePort(instance.port);
-    }
+    await this.mutateState(async () => {
+      // Deallocate port if it was allocated
+      if (instance.port > 0) {
+        await deallocatePort(instance.port);
+      }
 
-    // Remove from instances
-    this.instances.delete(name);
+      // Remove from instances
+      this.instances.delete(name);
 
-    // Clean up data directory unless the caller asked to keep it
-    if (!options.keepData && (await this.pathExists(instance.volume))) {
-      await rm(instance.volume, { recursive: true });
-    }
+      // Clean up data directory unless the caller asked to keep it
+      if (!options.keepData && (await this.pathExists(instance.volume))) {
+        await rm(instance.volume, { recursive: true });
+      }
 
-    // Update compose file and save instances
-    await this.updateComposeFile();
-    await this.saveInstances();
+      // Update compose file and save instances
+      await this.updateComposeFile();
+      await this.saveInstances();
+    });
   }
 
   public async startDatabase(name: string): Promise<void> {
@@ -337,22 +364,36 @@ export class DockerManager {
       return;
     }
 
-    // Ensure compose file is up to date
-    await this.updateComposeFile();
+    // Regenerate the compose file from fresh state so a concurrent process's
+    // instances aren't dropped from it.
+    await this.mutateState(() => this.updateComposeFile());
 
     const serviceName = `${name}-db`;
 
     try {
+      // The compose call (which may pull images for minutes) runs outside the
+      // state lock; only the status write is serialized.
       await this.executeDockerCompose(['up', '-d', serviceName]);
-      instance.status = 'running';
-      this.instances.set(name, instance);
-      await this.saveInstances();
+      await this.setInstanceStatus(name, 'running');
     } catch (error) {
-      instance.status = 'error';
-      this.instances.set(name, instance);
-      await this.saveInstances();
+      await this.setInstanceStatus(name, 'error');
+      if (error instanceof DockerNotReadyError) {
+        throw error; // keep the Environment classification for the CLI layer
+      }
       throw new Error(`Failed to start database '${name}': ${error}`);
     }
+  }
+
+  private async setInstanceStatus(name: string, status: DatabaseInstance['status']): Promise<void> {
+    await this.mutateState(async () => {
+      const current = this.instances.get(name);
+      if (!current || current.status === 'embedded') {
+        return;
+      }
+      current.status = status;
+      this.instances.set(name, current);
+      await this.saveInstances();
+    });
   }
 
   public async stopDatabase(name: string): Promise<void> {
@@ -366,25 +407,25 @@ export class DockerManager {
       return;
     }
 
-    // Ensure compose file exists
-    await this.updateComposeFile();
+    // Ensure compose file exists, regenerated from fresh state
+    await this.mutateState(() => this.updateComposeFile());
 
     const serviceName = `${name}-db`;
 
     try {
       await this.executeDockerCompose(['stop', serviceName]);
-      instance.status = 'stopped';
-      this.instances.set(name, instance);
-      await this.saveInstances();
+      await this.setInstanceStatus(name, 'stopped');
     } catch (error) {
-      instance.status = 'error';
-      this.instances.set(name, instance);
-      await this.saveInstances();
+      await this.setInstanceStatus(name, 'error');
+      if (error instanceof DockerNotReadyError) {
+        throw error; // keep the Environment classification for the CLI layer
+      }
       throw new Error(`Failed to stop database '${name}': ${error}`);
     }
   }
 
   private async executeDockerCompose(args: string[]): Promise<string> {
+    await this.ensureDockerReady();
     const composeFilePath = await getComposeFilePath();
 
     return new Promise((resolve, reject) => {
@@ -417,48 +458,42 @@ export class DockerManager {
     });
   }
 
-  public async startAllDatabases(): Promise<void> {
-    try {
-      // Ensure compose file is up to date
-      await this.updateComposeFile();
+  private async setAllInstanceStatuses(status: DatabaseInstance['status']): Promise<void> {
+    await this.mutateState(async () => {
+      for (const [name, instance] of this.instances) {
+        if (instance.status === 'embedded') continue;
+        instance.status = status;
+        this.instances.set(name, instance);
+      }
+      await this.saveInstances();
+    });
+  }
 
+  public async startAllDatabases(): Promise<void> {
+    // Regenerate the compose file from fresh state before touching Docker
+    await this.mutateState(() => this.updateComposeFile());
+    try {
       await this.executeDockerCompose(['up', '-d']);
-      for (const [name, instance] of this.instances) {
-        if (instance.status === 'embedded') continue;
-        instance.status = 'running';
-        this.instances.set(name, instance);
-      }
-      await this.saveInstances();
+      await this.setAllInstanceStatuses('running');
     } catch (error) {
-      for (const [name, instance] of this.instances) {
-        if (instance.status === 'embedded') continue;
-        instance.status = 'error';
-        this.instances.set(name, instance);
+      await this.setAllInstanceStatuses('error');
+      if (error instanceof DockerNotReadyError) {
+        throw error;
       }
-      await this.saveInstances();
       throw new Error(`Failed to start databases: ${error}`);
     }
   }
 
   public async stopAllDatabases(): Promise<void> {
+    await this.mutateState(() => this.updateComposeFile());
     try {
-      // Ensure compose file exists
-      await this.updateComposeFile();
-
       await this.executeDockerCompose(['stop']);
-      for (const [name, instance] of this.instances) {
-        if (instance.status === 'embedded') continue;
-        instance.status = 'stopped';
-        this.instances.set(name, instance);
-      }
-      await this.saveInstances();
+      await this.setAllInstanceStatuses('stopped');
     } catch (error) {
-      for (const [name, instance] of this.instances) {
-        if (instance.status === 'embedded') continue;
-        instance.status = 'error';
-        this.instances.set(name, instance);
+      await this.setAllInstanceStatuses('error');
+      if (error instanceof DockerNotReadyError) {
+        throw error;
       }
-      await this.saveInstances();
       throw new Error(`Failed to stop databases: ${error}`);
     }
   }

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -1,0 +1,25 @@
+// Semantic exit codes — the contract an orchestrator scripts against.
+// Documented in AUTOMATION.md; changing a value is a breaking change.
+export const ExitCode = {
+  // The operation completed (including honest no-ops like `init --exists-ok`
+  // on an existing instance).
+  Success: 0,
+  // Unexpected failure: bugs, I/O errors, anything without a more specific
+  // code. Retrying may or may not help.
+  Error: 1,
+  // The invocation itself is invalid (unknown command, bad flag combination).
+  // Retrying the same invocation will never help.
+  Usage: 2,
+  // The named resource (instance, snapshot) does not exist.
+  NotFound: 3,
+  // The resource already exists and the operation refuses to overwrite it.
+  Conflict: 4,
+  // The resource exists but is in the wrong state for this operation
+  // (not running, unsupported engine, cross-engine pair, missing --execute).
+  Precondition: 5,
+  // The environment cannot run the operation (Docker missing or not running,
+  // Compose plugin absent).
+  Environment: 6,
+} as const;
+
+export type ExitCodeValue = (typeof ExitCode)[keyof typeof ExitCode];

--- a/src/core/lock.ts
+++ b/src/core/lock.ts
@@ -1,0 +1,95 @@
+import { mkdir, open, readFile, rm } from 'fs/promises';
+import * as path from 'path';
+import { getDataDirectory } from './config.js';
+
+// Cross-process mutex over the local state files (instances.json,
+// port-allocations.json, docker-compose.yml). Orchestrators retry tasks and
+// run them concurrently; without this, two hayai processes interleave their
+// read-modify-write cycles and silently drop instances from the inventory.
+//
+// Implementation: O_EXCL lock file in the data directory holding pid + start
+// time. A lock older than STALE_MS, or whose pid is gone, is broken. This is
+// advisory and single-host — exactly the scope of the state it protects.
+
+const LOCK_FILE = '.hayai.lock';
+const STALE_MS = 60_000;
+const ACQUIRE_TIMEOUT_MS = 30_000;
+const RETRY_DELAY_MS = 150;
+
+interface LockInfo {
+  pid: number;
+  acquiredAt: number;
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function tryBreakStaleLock(lockPath: string): Promise<void> {
+  let info: LockInfo;
+  try {
+    info = JSON.parse(await readFile(lockPath, 'utf-8')) as LockInfo;
+  } catch {
+    // Unreadable or vanished — if it still exists it is corrupt; remove it.
+    await rm(lockPath, { force: true }).catch(() => undefined);
+    return;
+  }
+
+  const stale = Date.now() - info.acquiredAt > STALE_MS || !pidAlive(info.pid);
+  if (stale) {
+    await rm(lockPath, { force: true }).catch(() => undefined);
+  }
+}
+
+export async function acquireStateLock(): Promise<() => Promise<void>> {
+  const dataDir = await getDataDirectory();
+  // First run in a fresh project: the data directory the lock lives in may
+  // not exist yet.
+  await mkdir(dataDir, { recursive: true });
+  const lockPath = path.join(dataDir, LOCK_FILE);
+  const deadline = Date.now() + ACQUIRE_TIMEOUT_MS;
+
+  for (;;) {
+    try {
+      // 'wx' — O_CREAT | O_EXCL: creation is the atomic acquisition.
+      const handle = await open(lockPath, 'wx');
+      const info: LockInfo = { pid: process.pid, acquiredAt: Date.now() };
+      await handle.writeFile(JSON.stringify(info));
+      await handle.close();
+
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        await rm(lockPath, { force: true }).catch(() => undefined);
+      };
+    } catch (error: any) {
+      if (error.code !== 'EEXIST') {
+        throw error;
+      }
+      await tryBreakStaleLock(lockPath);
+      if (Date.now() > deadline) {
+        throw new Error(
+          `Timed out waiting for the hayai state lock (${lockPath}). ` +
+            'Another hayai process may be stuck; remove the file if you are sure none is running.',
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+}
+
+// Convenience wrapper: run fn with the state lock held, always releasing.
+export async function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
+  const release = await acquireStateLock();
+  try {
+    return await fn();
+  } finally {
+    await release();
+  }
+}

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -1,0 +1,47 @@
+import { ExitCode, ExitCodeValue } from './exit-codes.js';
+
+// Machine-readable envelope for --json mode. The shape is part of the
+// automation contract (AUTOMATION.md): stdout carries exactly one JSON
+// document; human-facing chatter goes to stderr.
+export interface JsonEnvelope {
+  ok: boolean;
+  command: string;
+  // Present on success; on failure it may carry partial results (e.g. which
+  // databases a sync did manage to create before erroring).
+  data?: unknown;
+  error?: {
+    code: ExitCodeValue;
+    message: string;
+  };
+}
+
+export function emitSuccess(command: string, data?: unknown): void {
+  const envelope: JsonEnvelope = { ok: true, command };
+  if (data !== undefined) {
+    envelope.data = data;
+  }
+  console.log(JSON.stringify(envelope, null, 2));
+}
+
+// Prints the error envelope to stdout (the machine channel) and returns the
+// exit code so callers can `process.exit(emitFailure(...))`.
+export function emitFailure(
+  command: string,
+  code: ExitCodeValue,
+  message: string,
+  data?: unknown,
+): ExitCodeValue {
+  const envelope: JsonEnvelope = {
+    ok: false,
+    command,
+    error: { code, message },
+  };
+  if (data !== undefined) {
+    envelope.data = data;
+  }
+  console.log(JSON.stringify(envelope, null, 2));
+  return code;
+}
+
+export { ExitCode };
+export type { ExitCodeValue };

--- a/src/tests/integration/automation.test.ts
+++ b/src/tests/integration/automation.test.ts
@@ -1,0 +1,174 @@
+import { chmod, mkdir, readFile, writeFile } from 'fs/promises';
+import * as path from 'path';
+import { createProject, destroyProject, runCli, CliResult } from './helpers.js';
+
+/**
+ * Verifies the automation contract (AUTOMATION.md): JSON envelopes on stdout,
+ * semantic exit codes, idempotent verbs, refusal to prompt under --json, and
+ * state-lock safety under concurrent mutations. Embedded engines are used
+ * throughout so the suite stays fast — the contract layer is engine-agnostic.
+ */
+describe('automation contract', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('automation');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  function envelope(result: CliResult): any {
+    return JSON.parse(result.stdout);
+  }
+
+  it('init --json emits a success envelope and creates the instance', async () => {
+    const result = await runCli(['init', '-n', 'auto', '-e', 'sqlite', '--json'], projectDir);
+    expect(result.code).toBe(0);
+
+    const body = envelope(result);
+    expect(body.ok).toBe(true);
+    expect(body.command).toBe('init');
+    expect(body.data.created).toBe(true);
+    expect(body.data.instance.name).toBe('auto');
+  });
+
+  it('init is idempotent with --exists-ok and conflicts without it', async () => {
+    const retry = await runCli(
+      ['init', '-n', 'auto', '-e', 'sqlite', '--exists-ok', '--json'],
+      projectDir,
+    );
+    expect(retry.code).toBe(0);
+    expect(envelope(retry).data.created).toBe(false);
+
+    const conflict = await runCli(['init', '-n', 'auto', '-e', 'sqlite', '--json'], projectDir);
+    expect(conflict.code).toBe(4);
+    expect(envelope(conflict).ok).toBe(false);
+    expect(envelope(conflict).error.code).toBe(4);
+
+    // Same name, different engine: --exists-ok must NOT mask a real conflict
+    const wrongEngine = await runCli(
+      ['init', '-n', 'auto', '-e', 'duckdb', '--exists-ok', '--json'],
+      projectDir,
+    );
+    expect(wrongEngine.code).toBe(4);
+  });
+
+  it('init --json refuses to prompt when required inputs are missing', async () => {
+    const result = await runCli(['init', '--json'], projectDir);
+    expect(result.code).toBe(2);
+    expect(envelope(result).error.code).toBe(2);
+  });
+
+  it('unknown instances exit 3 with a machine-readable error', async () => {
+    const start = await runCli(['start', 'ghost', '--json'], projectDir);
+    expect(start.code).toBe(3);
+    expect(envelope(start).error.code).toBe(3);
+
+    const snapshot = await runCli(['snapshot', 'ghost', '--json'], projectDir);
+    expect(snapshot.code).toBe(3);
+
+    const restore = await runCli(['restore', 'no-such-file.sql', '--json', '--force'], projectDir);
+    expect(restore.code).toBe(3);
+  });
+
+  it('remove --json without --force refuses instead of prompting', async () => {
+    const result = await runCli(['remove', 'auto', '--json'], projectDir);
+    expect(result.code).toBe(5);
+    expect(envelope(result).error.code).toBe(5);
+  });
+
+  it('remove is idempotent with --missing-ok', async () => {
+    const missing = await runCli(['remove', 'ghost', '--missing-ok', '--json'], projectDir);
+    expect(missing.code).toBe(0);
+    expect(envelope(missing).data.removed).toBe(false);
+
+    const notFound = await runCli(['remove', 'ghost', '--json', '--force'], projectDir);
+    expect(notFound.code).toBe(3);
+  });
+
+  it('merge without --execute reports a preview, not an execution', async () => {
+    // Embedded engines cannot merge, so use two sqlite instances only to get
+    // past name resolution; the precondition (unsupported engine) must win.
+    await runCli(['init', '-n', 'auto2', '-e', 'sqlite', '--json'], projectDir);
+    const result = await runCli(['merge', '-s', 'auto', '-t', 'auto2', '--json'], projectDir);
+    // sqlite instances are 'embedded', not 'running' → precondition
+    expect(result.code).toBe(5);
+    expect(envelope(result).ok).toBe(false);
+  });
+
+  it('concurrent inits serialize through the state lock without losing instances', async () => {
+    const names = ['c1', 'c2', 'c3', 'c4', 'c5'];
+    const results = await Promise.all(
+      names.map((name) => runCli(['init', '-n', name, '-e', 'sqlite', '--json'], projectDir)),
+    );
+
+    for (const result of results) {
+      expect(result.code).toBe(0);
+    }
+
+    // Every instance must have survived every other process's save
+    const instances = JSON.parse(
+      await readFile(path.join(projectDir, 'data', 'instances.json'), 'utf-8'),
+    );
+    for (const name of names) {
+      expect(instances[name]).toBeDefined();
+    }
+  });
+
+  it('stdout carries exactly one parseable JSON document in --json mode', async () => {
+    const result = await runCli(['list', '--json'], projectDir);
+    expect(result.code).toBe(0);
+    // JSON.parse on the full stdout throws if anything else leaked into it
+    const body = envelope(result);
+    expect(body.command).toBe('list');
+    expect(Array.isArray(body.data.instances)).toBe(true);
+  });
+
+  it('embedded engines work without a Docker daemon', async () => {
+    // A broken `docker` shim first in PATH simulates a machine where the
+    // daemon is unusable; host tools (tar) stay available. The CLI must not
+    // require the daemon for file-based engines or for reading state.
+    const fakeBin = path.join(projectDir, 'fake-bin');
+    await mkdir(fakeBin, { recursive: true });
+    const shim = path.join(fakeBin, 'docker');
+    await writeFile(shim, '#!/bin/sh\nexit 1\n');
+    await chmod(shim, 0o755);
+    const noDocker = { PATH: `${fakeBin}:${process.env.PATH ?? ''}` };
+
+    const init = await runCli(
+      ['init', '-n', 'nodocker', '-e', 'sqlite', '--json'],
+      projectDir,
+      60_000,
+      noDocker,
+    );
+    expect(init.code).toBe(0);
+
+    const list = await runCli(['list', '--json'], projectDir, 60_000, noDocker);
+    expect(list.code).toBe(0);
+
+    const snapshot = await runCli(['snapshot', 'nodocker', '--json'], projectDir, 60_000, noDocker);
+    expect(snapshot.code).toBe(0);
+
+    // And when Docker IS required, the failure is the documented exit 6
+    const start = await runCli(['start', 'nodocker', '--json'], projectDir, 60_000, noDocker);
+    // embedded start is a no-op success; use a containerized engine instead
+    expect(start.code).toBe(0);
+
+    await runCli(
+      ['init', '-n', 'needsdocker', '-e', 'redis', '--json'],
+      projectDir,
+      60_000,
+      noDocker,
+    );
+    const startContainer = await runCli(
+      ['start', 'needsdocker', '--json'],
+      projectDir,
+      60_000,
+      noDocker,
+    );
+    expect(startContainer.code).toBe(6);
+    expect(envelope(startContainer).error.code).toBe(6);
+  });
+});

--- a/src/tests/integration/helpers.ts
+++ b/src/tests/integration/helpers.ts
@@ -18,11 +18,12 @@ function run(
   args: string[],
   cwd: string,
   timeoutMs = 180_000,
+  envOverrides: Record<string, string> = {},
 ): Promise<CliResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
-      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1', CI: 'true' },
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1', CI: 'true', ...envOverrides },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -50,8 +51,13 @@ function run(
   });
 }
 
-export function runCli(args: string[], cwd: string, timeoutMs?: number): Promise<CliResult> {
-  return run(process.execPath, [CLI_PATH, ...args], cwd, timeoutMs);
+export function runCli(
+  args: string[],
+  cwd: string,
+  timeoutMs?: number,
+  envOverrides?: Record<string, string>,
+): Promise<CliResult> {
+  return run(process.execPath, [CLI_PATH, ...args], cwd, timeoutMs, envOverrides);
 }
 
 export function runDocker(args: string[], cwd: string, timeoutMs?: number): Promise<CliResult> {


### PR DESCRIPTION
## Context

The audit's central architectural claim is that hayai's durable niche is being the **control plane of the persistence layer** — verbs reliable enough to be called by an Airflow DAG or a systemd timer. That requires what the audit names the *automation-grade contract*: machine-readable output, semantic exit codes, idempotency, zero prompts, and locked state. None of it existed: output was human text, every failure was `exit(1)`, `init` exploded on retry, confirmations hung non-interactive callers, and two concurrent hayai processes could silently lose instances from `instances.json` via stale read-modify-write cycles.

## What this PR does

**1. Semantic exit codes** (`core/exit-codes.ts`, documented in the new `AUTOMATION.md`):
`0` Success · `1` Error · `2` Usage · `3` NotFound · `4` Conflict · `5` Precondition · `6` Environment. An orchestrator can decide retry-vs-fail from the code alone.

**2. `--json` mode on every state-changing verb** (`init`, `start`, `stop`, `remove`, `snapshot`, `restore`, `clone`, `merge`, `sync`, `export`, `list`): exactly one `{ok, command, data?, error?}` envelope on stdout; all human chatter on stderr; prompts disabled — a verb that would need confirmation exits `5` naming the flag instead of hanging. `list --format json` and `connect --json` keep their historical raw shapes as documented exceptions.

**3. Idempotency**: `init --exists-ok` (same name+engine → exit 0, `created:false`; different engine still conflicts, including on the create race) and `remove --missing-ok`. `sync` was already additive; its never-implemented `--force` flag is removed and the additive design documented.

**4. State locking** (`core/lock.ts`): advisory O_EXCL lock over the local state, with **reload-inside-the-lock** in every `DockerManager` mutation — serializing writes alone would still lose instances saved from a stale in-memory map. Stale locks are broken (dead pid or >60s); slow Docker operations run outside the lock.

**5. Lazy Docker verification**: Docker is checked on the first daemon-touching call and failure throws a typed error mapped to exit `6`. `init`, `list`, `connect`, `export` and all embedded-engine operations now work with **no Docker daemon at all** — previously even `hayai init -e sqlite` died without one.

**6. Dead-flag cleanup in touched files**: `start/stop --all` now works as the explicit form of omitting the name (name + `--all` is a usage error).

## How it was verified

- New `automation.test.ts` exercises every promise in `AUTOMATION.md` end-to-end via the compiled CLI: envelope shapes, each exit code on its documented path, both idempotency flags (including the engine-mismatch guard), prompt refusal under `--json`, **five concurrent `init` processes with zero lost instances**, stdout parseability, and the no-Docker matrix via a failing `docker` shim in PATH.
- Full integration suite: **32/32 green** against a live daemon. Unit tests 10/10, lint and format clean.

## Risks and rollback

- Exit codes for existing failure paths change from `1` to `2–6`. Scripts testing `$? -ne 0` are unaffected; scripts testing `$? -eq 1` specifically (unlikely) would need the new table. Pre-1.0 and now documented as contract.
- The lock adds one `mkdir` + `open(wx)` + reload per mutation — negligible against Docker operation costs; measured suite runtime is unchanged.
- Revert is a clean `git revert` of the three commits; no persistent state format changed (the lock file is transient).

## Out of scope (next PR)

- Engine tier system and per-engine support matrix (Frente 3).
- `hayai env --format airflow` and the Airflow provider (Estágio 1 do roadmap).
