### PR TITLE
hayai env + canonical Airflow integration (Stage 1 opening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mariadb, redis, sqlite, duckdb, leveldb, lmdb) has every data verb verified
   by CI; Tier 2 provisions fine but its data verbs are best-effort. The README
   support matrix states exactly what each engine gets.
+- `hayai env`: prints connection environment variables for the whole
+  inventory in `shell` (eval-able exports), `dotenv` and `airflow`
+  (`AIRFLOW_CONN_*`) formats. Engines without a well-known Airflow connection
+  type are skipped and listed on stderr rather than emitted broken.
+- `examples/airflow/`: the canonical ephemeral-staging DAG (provision → ETL →
+  snapshot → unconditional teardown) plus the connection-generation and
+  scheduled-maintenance patterns, all on plain BashOperator.
 
 ### Fixed
 - All data commands (`snapshot`, `restore`, `clone`, `merge`) addressed

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ hayai --version
 | `hayai start [name]` | Start database instances | `hayai start` or `hayai start mydb` |
 | `hayai stop [name]` | Stop database instances | `hayai stop` or `hayai stop mydb` |
 | `hayai list` | List all database instances | `hayai list --running` |
+| `hayai env` | Print connection env vars (shell, dotenv, airflow) | `eval "$(hayai env)"` |
 | `hayai studio [name]` | Open admin dashboards | `hayai studio mydb` |
 
 ### Configuration Commands
@@ -569,6 +570,7 @@ npm run lint
 - [.hayaidb Configuration](HAYAIDB.md) - Declarative database configuration guide
 - [Backup & Snapshots](ABOUT_BACKUP.md) - Complete backup and restoration guide
 - [Automation Contract](AUTOMATION.md) - JSON output, exit codes, idempotency and locking for scripts and orchestrators
+- [Airflow Integration](examples/airflow/README.md) - Ephemeral staging DAG, `AIRFLOW_CONN_*` generation and maintenance patterns
 
 ## 📄 License
 

--- a/examples/airflow/README.md
+++ b/examples/airflow/README.md
@@ -1,0 +1,77 @@
+# hayai + Apache Airflow
+
+Airflow orchestrates *when*; hayai owns *how* database instances are created,
+backed up, restored and destroyed. The two meet through the CLI — the same
+path dbt took into the Airflow ecosystem before dedicated operators existed.
+Everything here works with plain `BashOperator`; no provider package required.
+
+## Prerequisites (on the Airflow worker)
+
+- `npm install -g hayai-db` (Node ≥ 22.13)
+- A Docker daemon the worker can reach
+- A dedicated working directory for hayai state (its inventory is
+  per-directory), e.g. `/opt/airflow/hayai-staging`
+
+## Pattern 1 — ephemeral staging database per DAG run
+
+See [`hayai_ephemeral_staging.py`](hayai_ephemeral_staging.py) for the
+complete DAG. The shape:
+
+```
+provision (init --exists-ok && start)
+  → export_connection_uri (connect --uri → XCom)
+  → run_etl ($DATABASE_URL)
+  → snapshot (optional artifact)
+  → teardown (remove --force --missing-ok, trigger_rule=all_done)
+```
+
+Why this is retry-safe and crash-safe, in contract terms
+([AUTOMATION.md](../../AUTOMATION.md)):
+
+| Property | Mechanism |
+|---|---|
+| Retried provision doesn't fail on its own success | `init --exists-ok` exits 0 with `created: false` |
+| Retried teardown doesn't fail on missing instance | `remove --missing-ok` exits 0 with `removed: false` |
+| Teardown always runs | `trigger_rule="all_done"` + idempotent remove |
+| Failures are diagnosable from the exit code | 3 = not found, 5 = wrong state, 6 = Docker down |
+| XCom stays clean | stdout carries only data; banner and hints go to stderr |
+
+## Pattern 2 — hayai as the source of Airflow connections
+
+Airflow reads connections from `AIRFLOW_CONN_*` environment variables. hayai
+generates them from its inventory:
+
+```bash
+# In the environment that launches the scheduler/workers:
+set -a; source <(hayai env --format airflow); set +a
+```
+
+An instance named `analytics` running PostgreSQL becomes the Airflow
+connection id `analytics` (via `AIRFLOW_CONN_ANALYTICS`), usable by any
+`PostgresOperator`/hook. Engines without a well-known Airflow connection type
+are skipped and listed on stderr — nothing is emitted that Airflow would
+reject at task runtime. `hayai env --format airflow --json` gives the same
+data structured, including the skipped list.
+
+## Pattern 3 — scheduled maintenance
+
+Any hayai verb is cron-safe under the contract. A weekly snapshot DAG is one
+task:
+
+```python
+BashOperator(
+    task_id="weekly_snapshots",
+    cwd=HAYAI_PROJECT_DIR,
+    bash_command="hayai snapshot analytics --json && hayai snapshot cache --json",
+)
+```
+
+## Notes and limits
+
+- hayai state is **per working directory** — always set `cwd` (or `cd`) to
+  the same project directory across tasks and DAGs that share instances.
+- Concurrent tasks are safe: hayai serializes state mutations through an
+  advisory lock and re-reads state inside it.
+- Instances bind to the worker's localhost. For remote workers, the database
+  and the task that uses it must run on the same host (or the port must be
+  reachable) — hayai is a local control plane, not a network service.

--- a/examples/airflow/hayai_ephemeral_staging.py
+++ b/examples/airflow/hayai_ephemeral_staging.py
@@ -1,0 +1,92 @@
+"""Ephemeral staging database per DAG run, managed by hayai.
+
+The canonical hayai + Airflow pattern: provision a disposable PostgreSQL
+instance at the start of the run, execute the pipeline against it, and tear it
+down unconditionally at the end — even when upstream tasks fail.
+
+Every hayai call below leans on the automation contract (AUTOMATION.md):
+
+- ``--exists-ok`` / ``--missing-ok`` make provision and teardown idempotent,
+  so Airflow retries never fail on their own previous success.
+- ``--json`` keeps stdout parseable; semantic exit codes (3 not-found,
+  5 precondition, 6 docker-down) become task failures with a diagnosable
+  cause instead of a generic exit 1.
+- ``hayai connect --uri`` emits only the URI, so it drops straight into an
+  environment variable.
+
+Requirements on the worker: hayai-db installed globally (npm install -g
+hayai-db), Docker daemon available, and a working directory the DAG owns
+(HAYAI_PROJECT_DIR) — hayai state is per-directory.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pendulum
+from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
+
+HAYAI_PROJECT_DIR = os.environ.get("HAYAI_PROJECT_DIR", "/opt/airflow/hayai-staging")
+
+# One instance per logical date keeps concurrent runs isolated; ds_nodash is
+# already filesystem- and DNS-safe.
+INSTANCE = "staging-{{ ds_nodash }}"
+
+with DAG(
+    dag_id="hayai_ephemeral_staging",
+    description="Provision → load → verify → teardown a disposable PostgreSQL via hayai",
+    start_date=pendulum.datetime(2026, 1, 1, tz="UTC"),
+    schedule="@daily",
+    catchup=False,
+    tags=["hayai", "example"],
+) as dag:
+    provision = BashOperator(
+        task_id="provision_staging_db",
+        cwd=HAYAI_PROJECT_DIR,
+        bash_command=(
+            f"hayai init -n {INSTANCE} -e postgresql --exists-ok --json"
+            f" && hayai start {INSTANCE} --json"
+        ),
+    )
+
+    # The URI goes to XCom via stdout (do_xcom_push). The stderr banner does
+    # not pollute it — hayai keeps stdout machine-readable by contract.
+    export_uri = BashOperator(
+        task_id="export_connection_uri",
+        cwd=HAYAI_PROJECT_DIR,
+        bash_command=f"hayai connect {INSTANCE} --uri",
+        do_xcom_push=True,
+    )
+
+    # Stand-in for the real pipeline: any task that consumes DATABASE_URL.
+    run_etl = BashOperator(
+        task_id="run_etl",
+        cwd=HAYAI_PROJECT_DIR,
+        bash_command=(
+            'echo "loading into $DATABASE_URL" '
+            "&& psql \"$DATABASE_URL\" -c 'CREATE TABLE IF NOT EXISTS etl_check (id int)'"
+            " && psql \"$DATABASE_URL\" -c 'INSERT INTO etl_check VALUES (1)'"
+        ),
+        env={
+            "DATABASE_URL": "{{ ti.xcom_pull(task_ids='export_connection_uri') }}",
+        },
+    )
+
+    # Optional: keep an artifact of the staging state before it disappears.
+    snapshot = BashOperator(
+        task_id="snapshot_before_teardown",
+        cwd=HAYAI_PROJECT_DIR,
+        bash_command=f"hayai snapshot {INSTANCE} --json",
+    )
+
+    # trigger_rule=all_done: the teardown runs whether the pipeline succeeded
+    # or not — disposable means disposable. --missing-ok keeps retries green.
+    teardown = BashOperator(
+        task_id="teardown_staging_db",
+        cwd=HAYAI_PROJECT_DIR,
+        bash_command=f"hayai remove {INSTANCE} --force --missing-ok --json",
+        trigger_rule="all_done",
+    )
+
+    provision >> export_uri >> run_etl >> snapshot >> teardown

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1,0 +1,149 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getDockerManager } from '../../core/docker.js';
+import { DatabaseInstance } from '../../core/types.js';
+import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
+
+type EnvFormat = 'shell' | 'dotenv' | 'airflow';
+
+interface EnvCommandOptions {
+  format: string;
+  json?: boolean;
+}
+
+// KEY names must be valid POSIX environment variable identifiers.
+function envName(instanceName: string): string {
+  return instanceName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+// Airflow parses connections from AIRFLOW_CONN_* URIs where the scheme names
+// the connection type. Only engines with a well-known Airflow connection type
+// are emitted; the rest are skipped loudly rather than emitted with a scheme
+// Airflow would reject at task runtime.
+function airflowConnUri(instance: DatabaseInstance): string | null {
+  const uri = instance.connection_uri;
+  switch (instance.engine) {
+    case 'postgresql':
+    case 'timescaledb':
+      return uri.replace(/^postgresql:/, 'postgres:');
+    case 'mariadb':
+      return uri; // already mysql://user:pass@host:port/db
+    case 'redis':
+      return uri; // redis://host:port
+    default:
+      return null;
+  }
+}
+
+interface EnvEntry {
+  name: string;
+  value: string;
+}
+
+function buildEntries(
+  instances: DatabaseInstance[],
+  format: EnvFormat,
+): { entries: EnvEntry[]; skipped: Array<{ name: string; engine: string }> } {
+  const entries: EnvEntry[] = [];
+  const skipped: Array<{ name: string; engine: string }> = [];
+
+  for (const instance of instances) {
+    if (format === 'airflow') {
+      const uri = airflowConnUri(instance);
+      if (uri === null) {
+        skipped.push({ name: instance.name, engine: instance.engine });
+        continue;
+      }
+      entries.push({ name: `AIRFLOW_CONN_${envName(instance.name)}`, value: uri });
+    } else {
+      entries.push({ name: `${envName(instance.name)}_DB_URL`, value: instance.connection_uri });
+    }
+  }
+
+  return { entries, skipped };
+}
+
+export const envCommand = new Command('env')
+  .description('Print connection environment variables for all instances')
+  .option('--format <format>', 'Output format (shell, dotenv, airflow)', 'shell')
+  .option('--json', 'Machine-readable JSON output on stdout')
+  .addHelpText(
+    'after',
+    `
+${chalk.bold('Formats:')}
+  ${chalk.cyan('shell')}    export NAME_DB_URL='uri'      (eval "$(hayai env)")
+  ${chalk.cyan('dotenv')}   NAME_DB_URL=uri               (hayai env --format dotenv >> .env)
+  ${chalk.cyan('airflow')}  AIRFLOW_CONN_NAME=uri         (Airflow reads connections from env)
+
+${chalk.bold('Airflow usage:')}
+  ${chalk.cyan('# Load hayai instances as Airflow connections')}
+  set -a; source <(hayai env --format airflow); set +a
+
+  Engines without a well-known Airflow connection type are skipped and listed
+  on stderr — nothing is emitted that Airflow would reject at task runtime.
+
+${chalk.bold('Examples:')}
+  eval "$(hayai env)"                      ${chalk.gray('# export all URIs into this shell')}
+  hayai env --format dotenv >> .env        ${chalk.gray('# append to a dotenv file')}
+  hayai env --format airflow --json        ${chalk.gray('# structured, for tooling')}
+`,
+  )
+  .action(async (options: EnvCommandOptions) => {
+    const jsonMode = Boolean(options.json);
+    try {
+      const format = options.format as EnvFormat;
+      if (!['shell', 'dotenv', 'airflow'].includes(format)) {
+        fail(
+          'env',
+          ExitCode.Usage,
+          `Unknown format '${options.format}' (expected shell, dotenv or airflow)`,
+          jsonMode,
+        );
+      }
+
+      const dockerManager = getDockerManager();
+      await dockerManager.initialize();
+      const instances = dockerManager.getAllInstances();
+
+      const { entries, skipped } = buildEntries(instances, format);
+
+      if (jsonMode) {
+        succeed(
+          'env',
+          {
+            format,
+            variables: Object.fromEntries(entries.map((entry) => [entry.name, entry.value])),
+            skipped,
+          },
+          jsonMode,
+        );
+        return;
+      }
+
+      for (const entry of entries) {
+        if (format === 'shell') {
+          console.log(`export ${entry.name}=${shellQuote(entry.value)}`);
+        } else {
+          console.log(`${entry.name}=${entry.value}`);
+        }
+      }
+
+      // stderr, so pipes and eval stay clean
+      for (const skip of skipped) {
+        console.error(
+          chalk.yellow(
+            `⚠️  Skipped '${skip.name}': no Airflow connection type for engine '${skip.engine}'`,
+          ),
+        );
+      }
+      if (entries.length === 0 && skipped.length === 0) {
+        console.error(chalk.yellow('📦 No database instances found — run `hayai init` first'));
+      }
+    } catch (error) {
+      failFromError('env', error, jsonMode);
+    }
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { studioCommand } from './commands/studio.js';
 import { snapshotCommand } from './commands/snapshot.js';
 import { restoreCommand } from './commands/restore.js';
 import { connectCommand } from './commands/connect.js';
+import { envCommand } from './commands/env.js';
 import { exportCommand } from './commands/export.js';
 import { syncCommand } from './commands/sync.js';
 import { cloneCommand } from './commands/clone.js';
@@ -114,6 +115,7 @@ ${chalk.bold('COMMANDS')}
   ${chalk.cyan('stop')} [name]   Stop database instances
   ${chalk.cyan('list')}          List all database instances
   ${chalk.cyan('connect')} <name> Print connection details for an instance
+  ${chalk.cyan('env')}           Print connection env vars (shell, dotenv, airflow)
   ${chalk.cyan('remove')} <name> Remove a database instance
   ${chalk.cyan('logs')} <name>   View logs from a database instance
   ${chalk.cyan('studio')} [name] Open admin dashboards
@@ -149,6 +151,7 @@ ${chalk.bold('OPTIONS')}
 program.addCommand(initCommand);
 program.addCommand(listCommand);
 program.addCommand(connectCommand);
+program.addCommand(envCommand);
 program.addCommand(startCommand);
 program.addCommand(stopCommand);
 program.addCommand(removeCommand);
@@ -183,6 +186,7 @@ ${chalk.bold('COMMANDS')}
   ${chalk.cyan('stop')} [name]   Stop database instances
   ${chalk.cyan('list')}          List all database instances
   ${chalk.cyan('connect')} <name> Print connection details for an instance
+  ${chalk.cyan('env')}           Print connection env vars (shell, dotenv, airflow)
   ${chalk.cyan('remove')} <name> Remove a database instance
   ${chalk.cyan('logs')} <name>   View logs from a database instance
   ${chalk.cyan('studio')} [name] Open admin dashboards

--- a/src/tests/integration/env.test.ts
+++ b/src/tests/integration/env.test.ts
@@ -1,0 +1,81 @@
+import { createProject, destroyProject, runCli } from './helpers.js';
+
+/**
+ * `hayai env` — the inventory-to-environment bridge (Airflow pattern 2).
+ * Instances only need to exist, not run, so no containers are started here.
+ */
+describe('env command', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('env');
+    for (const [name, engine] of [
+      ['pg', 'postgresql'],
+      ['cache', 'redis'],
+      ['emb', 'sqlite'],
+      ['vec', 'qdrant'],
+    ]) {
+      const result = await runCli(['init', '-n', name, '-e', engine, '--json'], projectDir);
+      expect(result.code).toBe(0);
+    }
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('shell format emits eval-able export lines for every instance', async () => {
+    const result = await runCli(['env'], projectDir);
+    expect(result.code).toBe(0);
+
+    const lines = result.stdout.trim().split('\n');
+    expect(lines).toHaveLength(4);
+    for (const line of lines) {
+      expect(line).toMatch(/^export [A-Z0-9_]+_DB_URL='[^']+'$/);
+    }
+    expect(result.stdout).toContain('export PG_DB_URL=');
+    expect(result.stdout).toContain('export EMB_DB_URL=');
+  });
+
+  it('dotenv format emits KEY=VALUE without export', async () => {
+    const result = await runCli(['env', '--format', 'dotenv'], projectDir);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('CACHE_DB_URL=redis://localhost:');
+    expect(result.stdout).not.toContain('export ');
+  });
+
+  it('airflow format maps known connection types and skips the rest loudly', async () => {
+    const result = await runCli(['env', '--format', 'airflow'], projectDir);
+    expect(result.code).toBe(0);
+
+    // postgres:// (Airflow conn type), not postgresql://
+    expect(result.stdout).toMatch(/^AIRFLOW_CONN_PG=postgres:\/\//m);
+    expect(result.stdout).toMatch(/^AIRFLOW_CONN_CACHE=redis:\/\//m);
+
+    // No Airflow connection type for sqlite-as-file or qdrant → skipped, on
+    // stderr only, so sourcing stdout stays safe
+    expect(result.stdout).not.toContain('AIRFLOW_CONN_EMB');
+    expect(result.stdout).not.toContain('AIRFLOW_CONN_VEC');
+    expect(result.stderr).toContain("Skipped 'emb'");
+    expect(result.stderr).toContain("Skipped 'vec'");
+  });
+
+  it('--json returns the variables and the skipped list in the envelope', async () => {
+    const result = await runCli(['env', '--format', 'airflow', '--json'], projectDir);
+    expect(result.code).toBe(0);
+
+    const body = JSON.parse(result.stdout);
+    expect(body.ok).toBe(true);
+    expect(body.command).toBe('env');
+    expect(Object.keys(body.data.variables)).toEqual(
+      expect.arrayContaining(['AIRFLOW_CONN_PG', 'AIRFLOW_CONN_CACHE']),
+    );
+    expect(body.data.skipped.map((s: { name: string }) => s.name).sort()).toEqual(['emb', 'vec']);
+  });
+
+  it('rejects an unknown format with the Usage exit code', async () => {
+    const result = await runCli(['env', '--format', 'toml', '--json'], projectDir);
+    expect(result.code).toBe(2);
+    expect(JSON.parse(result.stdout).error.code).toBe(2);
+  });
+});


### PR DESCRIPTION
## Context

Stage 0 closed with the data verbs verified, the automation contract live and the tier system enforcing honesty. This PR opens **Stage 1 (Airflow ecosystem)** with the two entry-path deliverables the audit specified: `hayai env --format airflow` as the source of Airflow connections, and the canonical ephemeral-staging example with a complete DAG — both on plain `BashOperator`, no provider package required yet.

## What this PR does

**1. New `hayai env` command** — the bridge between hayai's inventory and anything that reads connections from the environment:

| Format | Output | Use |
|---|---|---|
| `shell` (default) | `export NAME_DB_URL='uri'` (quote-safe) | `eval "$(hayai env)"` |
| `dotenv` | `NAME_DB_URL=uri` | `hayai env --format dotenv >> .env` |
| `airflow` | `AIRFLOW_CONN_NAME=uri` with the scheme rewritten to the Airflow connection type | `set -a; source <(hayai env --format airflow); set +a` |

Engines without a well-known Airflow connection type (sqlite-as-file, vector/search/HTTP engines) are **skipped and listed on stderr** instead of being emitted with a scheme Airflow would reject at task runtime — a failure that would otherwise surface far from its cause. `--json` returns the variable map plus the skipped list in the standard envelope; unknown formats exit `2`. The command reads state only: instances don't need to be running and the Docker daemon is never touched.

**2. Canonical Airflow example** (`examples/airflow/`):
- `hayai_ephemeral_staging.py` — complete DAG: provision (`init --exists-ok` + `start`) → connection URI to XCom (`connect --uri`) → ETL against `$DATABASE_URL` → snapshot artifact → **unconditional teardown** (`remove --force --missing-ok`, `trigger_rule=all_done`). Retry- and crash-safety come from the automation contract, not DAG-side workarounds — the README maps each property to its mechanism.
- `README.md` — the three integration patterns (ephemeral staging, connection generation, scheduled maintenance) and the honest limits (per-directory state, localhost binding).

## How it was verified

- New `env.test.ts` integration suite: all three formats, quote-safety shape, the skip behavior on both channels, envelope contents, and the usage failure. Full suite: **41/41 across 7 suites**; unit 11/11; lint/format clean.

## Risks and rollback

- Purely additive: a new command, docs and examples. No existing behavior changes. Revert is a clean `git revert` of the two commits.
- The `airflow` format's engine coverage is intentionally narrow (postgres/timescale/mariadb/redis); widening it is a follow-up as conn-type mappings are validated against real Airflow versions.

## Next in Stage 1

- Composed stacks (`hayai init --stack timescale+telegraf-mqtt`).
- `airflow-provider-hayai` on PyPI wrapping the CLI in thin operators — the reward for the contract, once these patterns see real use.
