### PR TITLE
Add eight engines (22 → 30): MySQL and Valkey in Tier 1, new document category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `examples/airflow/`: the canonical ephemeral-staging DAG (provision → ETL →
   snapshot → unconditional teardown) plus the connection-generation and
   scheduled-maintenance patterns, all on plain BashOperator.
+- Eight new engines (22 → 30, new `document` category): **MySQL 8.4** and
+  **Valkey 8** land directly in Tier 1 — they reuse the verified
+  MariaDB/Redis data paths with each image's native client binaries
+  (mysqldump/mysql, valkey-cli) and ship their own end-to-end suites.
+  **ClickHouse** (with the `/play` UI in `hayai studio`), **Neo4j Community**
+  (bolt published; browser UI stays internal — hayai publishes one port per
+  instance), **OpenSearch** (single-node, security off for dev),
+  **Apache CouchDB** (Fauxton in `studio`), **Chroma**, and **MongoDB** —
+  the second documented source-available exception (SSPL) alongside
+  TimescaleDB, flagged by `init` at the moment of use.
 
 ### Fixed
 - All data commands (`snapshot`, `restore`, `clone`, `merge`) addressed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   
   ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)
   ![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
-  ![Databases](https://img.shields.io/badge/Databases-22-success)
+  ![Databases](https://img.shields.io/badge/Databases-30-success)
   ![CLI](https://img.shields.io/badge/CLI-Tool-blue)
   
   ![Security](https://img.shields.io/badge/Security-0%20vulnerabilities-brightgreen)
@@ -91,7 +91,7 @@ hayai studio
 
 ## 🎯 Key Features
 
-- **🔓 Open-Source Focused**: Open-source engines (one source-available: TimescaleDB)
+- **🔓 Open-Source Focused**: Open-source engines (two source-available exceptions, flagged at init: TimescaleDB, MongoDB)
 - **⚡ One Command Setup**: Initialize any database with a single command
 - **🐳 Docker-Powered**: Automated container management with health checks
 - **📁 Embedded Engines as Files**: SQLite, DuckDB, LevelDB, and LMDB are managed as plain host files — no container overhead
@@ -102,19 +102,21 @@ hayai studio
 
 ## 📦 Supported Databases
 
-All databases are **100% open-source** with permissive licenses:
+All engines are open-source, with two documented source-available exceptions (TimescaleDB under TSL, MongoDB under SSPL) that hayai flags at `init`: 
 
 <details>
-<summary><strong>SQL Databases (2)</strong></summary>
+<summary><strong>SQL Databases (3)</strong></summary>
 
 - **PostgreSQL** (PostgreSQL License) - Most popular open-source relational database
+- **MySQL** (GPL v2) - The most widely deployed open-source database
 - **MariaDB** (GPL v2) - MySQL community fork with enhanced features
 </details>
 
 <details>
-<summary><strong>Analytics Databases (1)</strong></summary>
+<summary><strong>Analytics Databases (2)</strong></summary>
 
 - **DuckDB** (MIT) - Analytics-focused columnar SQL database for OLAP workloads
+- **ClickHouse** (Apache 2.0) - Columnar OLAP database for real-time analytics
 </details>
 
 <details>
@@ -125,9 +127,10 @@ All databases are **100% open-source** with permissive licenses:
 </details>
 
 <details>
-<summary><strong>Key-Value Databases (3)</strong></summary>
+<summary><strong>Key-Value Databases (4)</strong></summary>
 
 - **Redis** (BSD 3-Clause) - High-performance in-memory key-value store
+- **Valkey** (BSD 3-Clause) - Linux Foundation fork of Redis, born after the 2024 relicense
 - **LevelDB** (BSD) - High-performance embedded key-value storage library
 - **TiKV** (Apache 2.0) - CNCF graduated distributed transactional key-value store
 </details>
@@ -139,25 +142,35 @@ All databases are **100% open-source** with permissive licenses:
 </details>
 
 <details>
-<summary><strong>Vector Databases (3)</strong></summary>
+<summary><strong>Vector Databases (4)</strong></summary>
 
 - **Qdrant** (Apache 2.0) - Vector database with REST API
+- **Chroma** (Apache 2.0) - Vector database popular in AI/LLM workflows
 - **Weaviate** (BSD 3-Clause) - Vector search engine with ML models
 - **Milvus** (Apache 2.0) - Vector database for AI applications
 </details>
 
 <details>
-<summary><strong>Graph Databases (2)</strong></summary>
+<summary><strong>Graph Databases (3)</strong></summary>
 
+- **Neo4j Community** (GPL v3) - The most widely used graph database
 - **ArangoDB** (Apache 2.0) - Multi-model database (graph, document, key-value)
 - **NebulaGraph** (Apache 2.0) - Distributed graph database with millisecond latency
 </details>
 
 <details>
-<summary><strong>Search Databases (2)</strong></summary>
+<summary><strong>Search Databases (3)</strong></summary>
 
 - **Meilisearch** (MIT) - Modern full-text search engine
 - **Typesense** (GPL v3) - Fast, typo-tolerant search engine
+- **OpenSearch** (Apache 2.0) - Community fork of Elasticsearch
+</details>
+
+<details>
+<summary><strong>Document Databases (2)</strong></summary>
+
+- **Apache CouchDB** (Apache 2.0) - Document store with offline-first replication
+- **MongoDB** (SSPL, source-available) - The most popular document database — documented licensing exception
 </details>
 
 <details>
@@ -171,7 +184,7 @@ All databases are **100% open-source** with permissive licenses:
 - **Apache HoraeDB** (Apache 2.0) - Cloud-native distributed time series database
 </details>
 
-**Total: 22 databases across 9 categories**
+**Total: 30 databases across 10 categories**
 
 ## 🎯 Engine Support Matrix
 
@@ -185,11 +198,14 @@ best-effort and not yet covered by the integration suite.
 | PostgreSQL | **1** | ✅ `pg_dump` | ✅ | ✅ | ✅ (target wins conflicts) |
 | TimescaleDB | **1** | ✅ `pg_dump` | ✅ | manual | manual |
 | MariaDB | **1** | ✅ `mariadb-dump` | ✅ | ✅ | ✅ (target wins conflicts) |
+| MySQL | **1** | ✅ `mysqldump` | ✅ | ✅ | ✅ (target wins conflicts) |
 | Redis | **1** | ✅ RDB | ✅ | ✅ | ✅ (source wins conflicts) |
+| Valkey | **1** | ✅ RDB | ✅ | ✅ | ✅ (source wins conflicts) |
 | SQLite, DuckDB, LevelDB, LMDB | **1** | ✅ archive | ✅ | ✅ file copy | — |
 | InfluxDB 2.x / 3 | 2 | ✅ `influx backup` | manual | manual | — |
 | Cassandra | 2 | ✅ `nodetool` | manual | manual | — |
 | Qdrant, Weaviate, ArangoDB, Meilisearch, Typesense, QuestDB, VictoriaMetrics, HoraeDB | 2 | ⚠️ generic archive¹ | manual | manual | — |
+| ClickHouse, Neo4j, OpenSearch, CouchDB, Chroma, MongoDB | 2 | ⚠️ generic archive¹ | manual | manual | — |
 | TiKV, Milvus, NebulaGraph | 2 (experimental²) | ⚠️ generic archive¹ | manual | manual | — |
 
 ¹ A `tar` of the running container's data directory — fine for dev checkpoints,

--- a/src/cli/commands/clone.ts
+++ b/src/cli/commands/clone.ts
@@ -25,8 +25,10 @@ interface CloneOptions extends CLIOptions {
 // Engines with a reliable native clone implementation
 const FULLY_COMPATIBLE_ENGINES = new Set([
   'postgresql', // pg_dump + psql
-  'mariadb', // mysqldump + mysql
+  'mariadb', // mariadb-dump + mariadb
+  'mysql', // mysqldump + mysql
   'redis', // BGSAVE + RDB copy
+  'valkey', // BGSAVE + RDB copy (valkey-cli)
   'sqlite', // host file copy (embedded)
   'duckdb', // host file copy (embedded)
   'leveldb', // host file copy (embedded)
@@ -143,10 +145,22 @@ async function cloneData(source: any, target: any): Promise<void> {
       await clonePostgreSQL(sourceContainer, targetContainer, source.environment);
       break;
     case 'mariadb':
-      await cloneMariaDB(sourceContainer, targetContainer, source.environment);
+      await cloneMariaDB(sourceContainer, targetContainer, source.environment, {
+        dump: 'mariadb-dump',
+        client: 'mariadb',
+      });
+      break;
+    case 'mysql':
+      await cloneMariaDB(sourceContainer, targetContainer, source.environment, {
+        dump: 'mysqldump',
+        client: 'mysql',
+      });
       break;
     case 'redis':
-      await cloneRedis(sourceContainer, targetContainer, target.name);
+      await cloneRedis(sourceContainer, targetContainer, target.name, 'redis-cli');
+      break;
+    case 'valkey':
+      await cloneRedis(sourceContainer, targetContainer, target.name, 'valkey-cli');
       break;
     default:
       // This situation should never happen due to compatibility validation
@@ -191,6 +205,7 @@ async function cloneMariaDB(
   sourceContainer: string,
   targetContainer: string,
   environment: Record<string, string> = {},
+  binaries: { dump: string; client: string } = { dump: 'mariadb-dump', client: 'mariadb' },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const rootPassword = getMariaDBRootPassword(environment);
@@ -204,8 +219,7 @@ async function cloneMariaDB(
         '-e',
         `MYSQL_PWD=${rootPassword}`,
         sourceContainer,
-        // mariadb:11 images ship only the mariadb-* client names
-        'mariadb-dump',
+        binaries.dump,
         '-u',
         'root',
         ...dumpTarget,
@@ -215,7 +229,16 @@ async function cloneMariaDB(
 
     const restoreProcess = spawn(
       'docker',
-      ['exec', '-i', '-e', `MYSQL_PWD=${rootPassword}`, targetContainer, 'mariadb', '-u', 'root'],
+      [
+        'exec',
+        '-i',
+        '-e',
+        `MYSQL_PWD=${rootPassword}`,
+        targetContainer,
+        binaries.client,
+        '-u',
+        'root',
+      ],
       { stdio: ['pipe', 'inherit', 'pipe'] },
     );
 
@@ -242,9 +265,10 @@ async function cloneRedis(
   sourceContainer: string,
   targetContainer: string,
   targetName: string,
+  cli: string = 'redis-cli',
 ): Promise<void> {
   // Persist the source dataset to its RDB file
-  await runDockerStep(['exec', sourceContainer, 'redis-cli', 'BGSAVE'], 'Redis backup failed');
+  await runDockerStep(['exec', sourceContainer, cli, 'BGSAVE'], 'Redis backup failed');
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   await runDockerStep(
@@ -450,8 +474,8 @@ export const cloneCommand = new Command('clone')
     `
 ${chalk.bold('Supported Engines (Fully Compatible):')}
   ${chalk.green('✅ postgresql')}   - Native pg_dump + psql
-  ${chalk.green('✅ mariadb')}      - Native mysqldump + mysql
-  ${chalk.green('✅ redis')}        - Native BGSAVE + RDB copy
+  ${chalk.green('✅ mariadb, mysql')} - Native dump + replay with each image's client
+  ${chalk.green('✅ redis, valkey')} - Native BGSAVE + RDB copy
   ${chalk.green('✅ sqlite, duckdb, leveldb, lmdb')} - Host file copy (embedded)
 
 ${chalk.bold('Unsupported Engines (Manual Clone Required):')}

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -31,8 +31,10 @@ function airflowConnUri(instance: DatabaseInstance): string | null {
     case 'timescaledb':
       return uri.replace(/^postgresql:/, 'postgres:');
     case 'mariadb':
+    case 'mysql':
       return uri; // already mysql://user:pass@host:port/db
     case 'redis':
+    case 'valkey':
       return uri; // redis://host:port
     default:
       return null;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -2,7 +2,12 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import { getTemplate, getAvailableTypes, getEnginesByType } from '../../core/templates.js';
+import {
+  getTemplate,
+  getAvailableTypes,
+  getEnginesByType,
+  getOpenSourceInfo,
+} from '../../core/templates.js';
 import { createDatabase, getDockerManager } from '../../core/docker.js';
 import { InitOptions } from '../../core/types.js';
 import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
@@ -18,6 +23,8 @@ const getDisplayName = (type: string): string => {
     graph: 'Graph',
     search: 'Search',
     embedded: 'Embedded',
+    analytics: 'Analytics',
+    document: 'Document',
   };
   return displayNames[type] || type.toUpperCase();
 };
@@ -180,6 +187,17 @@ export const initCommand = new Command('init')
         console.log(
           chalk.yellow(
             `\n⚠️  ${template.name} is experimental: hayai runs it as a single container, but it needs a multi-node cluster to work properly. Expect it to be partially or non-functional.`,
+          ),
+        );
+      }
+
+      // Source-available engines (TimescaleDB, MongoDB) are documented
+      // exceptions to the open-source catalog — say so at the moment of use.
+      const licenseInfo = getOpenSourceInfo()[config.engine];
+      if (licenseInfo && !licenseInfo.fullyOpenSource && !jsonMode) {
+        console.log(
+          chalk.yellow(
+            `\nℹ️  ${template.name} is source-available, not OSI open source (${licenseInfo.license}). ${licenseInfo.notes}`,
           ),
         );
       }

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -13,7 +13,7 @@ import { ExitCode, fail, failFromError, succeed } from '../cli-output.js';
 
 // Engines with a real, key/row-level merge. Anything else (or a cross-engine
 // pair) is refused rather than guessed at.
-const MERGEABLE_ENGINES = new Set(['postgresql', 'mariadb', 'redis']);
+const MERGEABLE_ENGINES = new Set(['postgresql', 'mariadb', 'mysql', 'redis', 'valkey']);
 
 interface MergeOptions extends CLIOptions {
   source: string;
@@ -81,10 +81,23 @@ async function mergeDatabases(sourceInstance: any, targetInstance: any): Promise
         targetContainer,
         sourceInstance.environment,
         targetInstance.environment,
+        { dump: 'mariadb-dump', client: 'mariadb' },
+      );
+      break;
+    case 'mysql':
+      await mergeMariaDB(
+        sourceContainer,
+        targetContainer,
+        sourceInstance.environment,
+        targetInstance.environment,
+        { dump: 'mysqldump', client: 'mysql' },
       );
       break;
     case 'redis':
-      await mergeRedis(sourceContainer, composeServiceName(targetInstance.name));
+      await mergeRedis(sourceContainer, composeServiceName(targetInstance.name), 'redis-cli');
+      break;
+    case 'valkey':
+      await mergeRedis(sourceContainer, composeServiceName(targetInstance.name), 'valkey-cli');
       break;
     default:
       // Unreachable: handleMerge validates the engine before calling here.
@@ -161,6 +174,7 @@ async function mergeMariaDB(
   targetContainer: string,
   sourceEnv: Record<string, string> = {},
   targetEnv: Record<string, string> = {},
+  binaries: { dump: string; client: string } = { dump: 'mariadb-dump', client: 'mariadb' },
 ): Promise<void> {
   console.log(chalk.yellow('🔄 Merging MariaDB databases...'));
 
@@ -179,8 +193,7 @@ async function mergeMariaDB(
         '-e',
         `MYSQL_PWD=${getMariaDBRootPassword(sourceEnv)}`,
         sourceContainer,
-        // mariadb:11 images ship only the mariadb-* client names
-        'mariadb-dump',
+        binaries.dump,
         '-u',
         'root',
         '--no-create-info',
@@ -198,7 +211,7 @@ async function mergeMariaDB(
         '-e',
         `MYSQL_PWD=${getMariaDBRootPassword(targetEnv)}`,
         targetContainer,
-        'mariadb',
+        binaries.client,
         '-u',
         'root',
         '--force',
@@ -218,11 +231,15 @@ async function mergeMariaDB(
   });
 }
 
-async function mergeRedis(sourceContainer: string, targetServiceHost: string): Promise<void> {
+async function mergeRedis(
+  sourceContainer: string,
+  targetServiceHost: string,
+  cli: string = 'redis-cli',
+): Promise<void> {
   console.log(chalk.yellow('🔄 Merging Redis databases...'));
 
   // SCAN instead of KEYS — KEYS blocks the server on large datasets
-  const keys = await scanRedisKeys(sourceContainer);
+  const keys = await scanRedisKeys(sourceContainer, cli);
   if (keys.length === 0) {
     return; // Nothing to merge
   }
@@ -234,7 +251,7 @@ async function mergeRedis(sourceContainer: string, targetServiceHost: string): P
   // service name, which doubles as its DNS name on the shared network.
   const failed: string[] = [];
   for (const key of keys) {
-    const ok = await migrateRedisKey(sourceContainer, targetServiceHost, key);
+    const ok = await migrateRedisKey(sourceContainer, targetServiceHost, key, cli);
     if (!ok) {
       failed.push(key);
     }
@@ -249,9 +266,9 @@ async function mergeRedis(sourceContainer: string, targetServiceHost: string): P
   console.log(chalk.gray(`   ${keys.length} keys merged`));
 }
 
-async function scanRedisKeys(container: string): Promise<string[]> {
+async function scanRedisKeys(container: string, cli: string = 'redis-cli'): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    const scanProcess = spawn('docker', ['exec', container, 'redis-cli', '--scan']);
+    const scanProcess = spawn('docker', ['exec', container, cli, '--scan']);
 
     let output = '';
     scanProcess.stdout.on('data', (data) => {
@@ -279,12 +296,13 @@ async function migrateRedisKey(
   sourceContainer: string,
   targetServiceHost: string,
   key: string,
+  cli: string = 'redis-cli',
 ): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const migrateProcess = spawn('docker', [
       'exec',
       sourceContainer,
-      'redis-cli',
+      cli,
       'MIGRATE',
       targetServiceHost,
       '6379',
@@ -529,8 +547,8 @@ ${chalk.bold('How Merge Works:')}
     the key with the source's value (MIGRATE … REPLACE)
 
 ${chalk.bold('Supported Engines (same engine on both sides):')}
-  • PostgreSQL, MariaDB: SQL-level merging (data-only)
-  • Redis: key-level merging with MIGRATE … COPY REPLACE
+  • PostgreSQL, MariaDB, MySQL: SQL-level merging (data-only)
+  • Redis, Valkey: key-level merging with MIGRATE … COPY REPLACE
 
 ${chalk.bold('Unsupported:')}
   • Cross-engine pairs and any other engine are refused — there is no safe

--- a/src/cli/commands/restore.ts
+++ b/src/cli/commands/restore.ts
@@ -30,7 +30,9 @@ const RESTORABLE_ENGINES = new Set([
   'postgresql',
   'timescaledb',
   'mariadb',
+  'mysql',
   'redis',
+  'valkey',
   ...EMBEDDED_ENGINES,
 ]);
 
@@ -101,14 +103,15 @@ async function restoreMariaDB(
   container: string,
   snapshotPath: string,
   env: Record<string, string>,
+  clientBinary: string = 'mariadb',
 ): Promise<void> {
   const password = getMariaDBRootPassword(env);
   // --all-databases dumps carry their own CREATE DATABASE / USE statements.
-  // mariadb:11 images ship only the mariadb-* client names.
+  // mariadb:11 ships only the mariadb-* client names; mysql:8 ships mysql.
   await restoreViaStdin(
-    ['exec', '-i', '-e', `MYSQL_PWD=${password}`, container, 'mariadb', '-u', 'root'],
+    ['exec', '-i', '-e', `MYSQL_PWD=${password}`, container, clientBinary, '-u', 'root'],
     snapshotPath,
-    'MariaDB',
+    'MariaDB/MySQL',
   );
 }
 
@@ -159,9 +162,20 @@ async function restoreInto(instance: DatabaseInstance, snapshotPath: string): Pr
         await resolveServiceContainer(instance.name),
         snapshotPath,
         instance.environment,
+        'mariadb',
+      );
+      break;
+    case 'mysql':
+      await restoreMariaDB(
+        await resolveServiceContainer(instance.name),
+        snapshotPath,
+        instance.environment,
+        'mysql',
       );
       break;
     case 'redis':
+    case 'valkey':
+      // Identical RDB-swap sequence: valkey keeps /data/dump.rdb semantics
       await restoreRedis(instance.name, snapshotPath);
       break;
     default:
@@ -319,8 +333,8 @@ export const restoreCommand = new Command('restore')
     `
 ${chalk.bold('Supported engines:')}
   ${chalk.green('✅ postgresql, timescaledb')}  - psql replays the SQL dump
-  ${chalk.green('✅ mariadb')}                  - mysql replays the SQL dump
-  ${chalk.green('✅ redis')}                    - RDB swapped in with the server stopped
+  ${chalk.green('✅ mariadb, mysql')}           - the SQL dump is replayed by the native client
+  ${chalk.green('✅ redis, valkey')}            - RDB swapped in with the server stopped
   ${chalk.green('✅ sqlite, duckdb, leveldb, lmdb')} - data directory extracted in place
 
 ${chalk.bold('Not supported (snapshot-only):')}

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -46,10 +46,17 @@ async function createSnapshot(instance: any, snapshotPath: string): Promise<void
       await createPostgreSQLSnapshot(container, snapshotPath, instance.environment);
       break;
     case 'mariadb':
-      await createMariaDBSnapshot(container, snapshotPath, instance.environment);
+      // mariadb:11 ships only the mariadb-* client names
+      await createMariaDBSnapshot(container, snapshotPath, instance.environment, 'mariadb-dump');
+      break;
+    case 'mysql':
+      await createMariaDBSnapshot(container, snapshotPath, instance.environment, 'mysqldump');
       break;
     case 'redis':
-      await createRedisSnapshot(container, snapshotPath);
+      await createRedisSnapshot(container, snapshotPath, 'redis-cli');
+      break;
+    case 'valkey':
+      await createRedisSnapshot(container, snapshotPath, 'valkey-cli');
       break;
     case 'influxdb2':
     case 'influxdb3':
@@ -92,6 +99,7 @@ async function createMariaDBSnapshot(
   container: string,
   snapshotPath: string,
   environment: Record<string, string> = {},
+  dumpBinary: string = 'mariadb-dump',
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const rootPassword = getMariaDBRootPassword(environment);
@@ -102,9 +110,7 @@ async function createMariaDBSnapshot(
         '-e',
         `MYSQL_PWD=${rootPassword}`,
         container,
-        // mariadb:11 images ship only the mariadb-* client names; the mysql*
-        // compatibility symlinks are gone.
-        'mariadb-dump',
+        dumpBinary,
         '-u',
         'root',
         '--all-databases',
@@ -124,10 +130,14 @@ async function createMariaDBSnapshot(
   });
 }
 
-async function createRedisSnapshot(container: string, snapshotPath: string): Promise<void> {
+async function createRedisSnapshot(
+  container: string,
+  snapshotPath: string,
+  cli: string = 'redis-cli',
+): Promise<void> {
   return new Promise((resolve, reject) => {
     // Create RDB backup
-    const bgsaveProcess = spawn('docker', ['exec', container, 'redis-cli', 'BGSAVE']);
+    const bgsaveProcess = spawn('docker', ['exec', container, cli, 'BGSAVE']);
 
     bgsaveProcess.on('close', async (code) => {
       if (code !== 0) {
@@ -288,7 +298,7 @@ async function createCassandraSnapshot(container: string, snapshotPath: string):
 
 // The snapshot file extension follows the engine's native backup format.
 function snapshotExtension(engine: string): string {
-  if (engine === 'redis') return 'rdb';
+  if (engine === 'redis' || engine === 'valkey') return 'rdb';
   if (engine.includes('influx') || engine === 'cassandra') return 'tar.gz';
   if (EMBEDDED_ENGINES.has(engine)) return 'tar.gz';
   return 'sql';

--- a/src/core/docker.ts
+++ b/src/core/docker.ts
@@ -642,12 +642,35 @@ export class DockerManager {
         return `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@localhost:${port}/${env.POSTGRES_DB}`;
 
       case 'mariadb':
+      case 'mysql':
         return `mysql://${env.MYSQL_USER}:${env.MYSQL_PASSWORD}@localhost:${port}/${env.MYSQL_DATABASE}`;
 
       case 'redis':
         // Unauthenticated by design — the image ignores REDIS_PASSWORD, so a
         // credentialed URI here would just be a false promise.
         return `redis://localhost:${port}`;
+
+      case 'valkey':
+        return `redis://localhost:${port}`;
+
+      case 'mongodb':
+        return `mongodb://${env.MONGO_INITDB_ROOT_USERNAME}:${env.MONGO_INITDB_ROOT_PASSWORD}@localhost:${port}/${env.MONGO_INITDB_DATABASE}?authSource=admin`;
+
+      case 'couchdb':
+        return `http://${env.COUCHDB_USER}:${env.COUCHDB_PASSWORD}@localhost:${port}`;
+
+      case 'neo4j':
+        // Bolt is the published port; NEO4J_AUTH is 'user/password'
+        return `bolt://${(env.NEO4J_AUTH || 'neo4j/password').replace('/', ':')}@localhost:${port}`;
+
+      case 'clickhouse':
+        return `http://${env.CLICKHOUSE_USER}:${env.CLICKHOUSE_PASSWORD}@localhost:${port}/${env.CLICKHOUSE_DB}`;
+
+      case 'opensearch':
+        return `http://localhost:${port}`;
+
+      case 'chroma':
+        return `http://localhost:${port}`;
 
       case 'cassandra':
         return `cassandra://localhost:${port}`;

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -506,6 +506,199 @@ export class DatabaseTemplates {
         },
       },
     });
+
+    // ✅ SQL Databases — wave 2
+    this.addTemplate('mysql', {
+      name: 'MySQL',
+      engine: {
+        name: 'mysql',
+        type: 'sql',
+        version: '8.4',
+        image: 'mysql:8.4',
+        ports: [3306],
+        volumes: ['/var/lib/mysql'],
+        environment: {
+          MYSQL_ROOT_PASSWORD: 'rootpassword',
+          MYSQL_DATABASE: 'database',
+          MYSQL_USER: 'admin',
+          MYSQL_PASSWORD: 'password',
+        },
+        healthcheck: {
+          test: 'mysqladmin ping -h localhost -u root -p${MYSQL_ROOT_PASSWORD}',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+    });
+
+    // ✅ Key-Value — wave 2
+    this.addTemplate('valkey', {
+      name: 'Valkey',
+      engine: {
+        name: 'valkey',
+        type: 'keyvalue',
+        version: '8',
+        image: 'valkey/valkey:8-alpine',
+        ports: [6379],
+        volumes: ['/data'],
+        // Unauthenticated, same rationale as redis: no decorative variables.
+        environment: {},
+        healthcheck: {
+          test: 'valkey-cli ping',
+          interval: '10s',
+          timeout: '3s',
+          retries: 5,
+        },
+      },
+    });
+
+    // ✅ Analytics — wave 2
+    this.addTemplate('clickhouse', {
+      name: 'ClickHouse',
+      engine: {
+        name: 'clickhouse',
+        type: 'analytics',
+        version: '24.8',
+        image: 'clickhouse/clickhouse-server:24.8',
+        // 8123 = HTTP (published; the play UI and most clients); 9000 = native
+        ports: [8123, 9000],
+        volumes: ['/var/lib/clickhouse'],
+        environment: {
+          CLICKHOUSE_DB: 'database',
+          CLICKHOUSE_USER: 'admin',
+          CLICKHOUSE_PASSWORD: 'password',
+        },
+        healthcheck: {
+          test: 'clickhouse-client --user ${CLICKHOUSE_USER} --password ${CLICKHOUSE_PASSWORD} --query "SELECT 1"',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+      admin_dashboard: {
+        enabled: true,
+        path: '/play',
+      },
+    });
+
+    // ✅ Graph — wave 2
+    this.addTemplate('neo4j', {
+      name: 'Neo4j Community',
+      engine: {
+        name: 'neo4j',
+        type: 'graph',
+        version: '5',
+        image: 'neo4j:5',
+        // 7687 (bolt, the client protocol) is published; 7474 (browser UI)
+        // stays internal — hayai publishes a single port per instance, and a
+        // database you can't connect an app to is worse than one without its
+        // web UI. No admin_dashboard is declared for the same reason.
+        ports: [7687, 7474],
+        volumes: ['/data'],
+        environment: {
+          NEO4J_AUTH: 'neo4j/password',
+        },
+        healthcheck: {
+          test: 'wget --no-verbose --tries=1 --spider http://localhost:7474 || exit 1',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+    });
+
+    // ✅ Search — wave 2
+    this.addTemplate('opensearch', {
+      name: 'OpenSearch',
+      engine: {
+        name: 'opensearch',
+        type: 'search',
+        version: '2.19',
+        image: 'opensearchproject/opensearch:2.19.0',
+        ports: [9200],
+        volumes: ['/usr/share/opensearch/data'],
+        environment: {
+          'discovery.type': 'single-node',
+          DISABLE_SECURITY_PLUGIN: 'true',
+          DISABLE_INSTALL_DEMO_CONFIG: 'true',
+          OPENSEARCH_JAVA_OPTS: '-Xms512m -Xmx512m',
+        },
+        healthcheck: {
+          test: 'curl -f http://localhost:9200/_cluster/health || exit 1',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+    });
+
+    // ✅ Document Databases — wave 2
+    this.addTemplate('couchdb', {
+      name: 'Apache CouchDB',
+      engine: {
+        name: 'couchdb',
+        type: 'document',
+        version: '3.4',
+        image: 'couchdb:3.4',
+        ports: [5984],
+        volumes: ['/opt/couchdb/data'],
+        environment: {
+          COUCHDB_USER: 'admin',
+          COUCHDB_PASSWORD: 'password',
+        },
+        healthcheck: {
+          test: 'curl -f http://localhost:5984/_up || exit 1',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+      admin_dashboard: {
+        enabled: true,
+        path: '/_utils',
+      },
+    });
+
+    // ⚠️ Source-available (SSPL) — documented exception, see README
+    this.addTemplate('mongodb', {
+      name: 'MongoDB',
+      engine: {
+        name: 'mongodb',
+        type: 'document',
+        version: '8',
+        image: 'mongo:8',
+        ports: [27017],
+        volumes: ['/data/db'],
+        environment: {
+          MONGO_INITDB_ROOT_USERNAME: 'admin',
+          MONGO_INITDB_ROOT_PASSWORD: 'password',
+          MONGO_INITDB_DATABASE: 'database',
+        },
+        healthcheck: {
+          test: 'mongosh --quiet --eval "db.adminCommand({ping: 1})"',
+          interval: '10s',
+          timeout: '5s',
+          retries: 5,
+        },
+      },
+    });
+
+    // ✅ Vector — wave 2
+    this.addTemplate('chroma', {
+      name: 'Chroma',
+      engine: {
+        name: 'chroma',
+        type: 'vector',
+        version: 'latest',
+        image: 'chromadb/chroma:latest',
+        ports: [8000],
+        volumes: ['/chroma/chroma'],
+        environment: {},
+        // No healthcheck: the slim image ships neither curl nor wget, and a
+        // check that can never pass reads as a permanently unhealthy service.
+      },
+    });
   }
 
   private static addTemplate(key: string, template: DatabaseTemplate): void {
@@ -671,6 +864,46 @@ export class DatabaseTemplates {
         fullyOpenSource: true,
         notes: 'Apache HoraeDB - Distributed, cloud-native, in incubation',
       },
+      mysql: {
+        license: 'GPL v2 (Community Edition)',
+        fullyOpenSource: true,
+        notes: 'The most widely deployed open-source database',
+      },
+      valkey: {
+        license: 'BSD 3-Clause',
+        fullyOpenSource: true,
+        notes: 'Linux Foundation fork of Redis, created after the 2024 relicense',
+      },
+      clickhouse: {
+        license: 'Apache 2.0',
+        fullyOpenSource: true,
+        notes: 'Columnar OLAP database for real-time analytics',
+      },
+      neo4j: {
+        license: 'GPL v3 (Community Edition)',
+        fullyOpenSource: true,
+        notes: 'Most widely used graph database; Enterprise features are commercial',
+      },
+      opensearch: {
+        license: 'Apache 2.0',
+        fullyOpenSource: true,
+        notes: 'Community fork of Elasticsearch/Kibana',
+      },
+      couchdb: {
+        license: 'Apache 2.0',
+        fullyOpenSource: true,
+        notes: 'Document store with offline-first replication',
+      },
+      mongodb: {
+        license: 'SSPL v1 (source-available)',
+        fullyOpenSource: false,
+        notes: 'SSPL is not OSI-approved — included as a documented exception for its ubiquity',
+      },
+      chroma: {
+        license: 'Apache 2.0',
+        fullyOpenSource: true,
+        notes: 'Vector database popular in AI/LLM workflows',
+      },
     };
   }
 }
@@ -721,7 +954,9 @@ const TIER1_ENGINES = new Set([
   'postgresql',
   'timescaledb',
   'mariadb',
+  'mysql',
   'redis',
+  'valkey',
   'sqlite',
   'duckdb',
   'leveldb',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,7 +53,8 @@ export interface DatabaseEngine {
     | 'search'
     | 'graph'
     | 'embedded'
-    | 'analytics';
+    | 'analytics'
+    | 'document';
   version: string;
   image: string;
   ports: number[];

--- a/src/tests/integration/mysql.test.ts
+++ b/src/tests/integration/mysql.test.ts
@@ -1,0 +1,93 @@
+import {
+  composeExec,
+  createProject,
+  destroyProject,
+  latestSnapshot,
+  runCli,
+  waitFor,
+} from './helpers.js';
+
+// Defaults declared by the mysql template in src/core/templates.ts
+const ROOT_PASSWORD = 'rootpassword';
+const DB = 'database';
+
+// mysql:8 ships the classic mysql client (unlike mariadb:11)
+async function mysql(projectDir: string, service: string, sql: string) {
+  return composeExec(projectDir, service, [
+    'mysql',
+    '-uroot',
+    `-p${ROOT_PASSWORD}`,
+    '-N',
+    '-e',
+    sql,
+    DB,
+  ]);
+}
+
+/**
+ * MySQL earns its Tier 1 badge here: it reuses MariaDB's dump/replay logic but
+ * with the mysql/mysqldump binaries the official image actually ships — the
+ * exact divergence that broke MariaDB support in 0.8.x, verified from the
+ * other direction.
+ */
+describe('mysql data lifecycle', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('mysql');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('init and start bring up a healthy instance', async () => {
+    const initResult = await runCli(['init', '-n', 'mys', '-e', 'mysql', '-y'], projectDir);
+    expect(initResult.code).toBe(0);
+
+    const startResult = await runCli(['start', 'mys'], projectDir, 300_000);
+    expect(startResult.code).toBe(0);
+
+    await waitFor(
+      async () => (await mysql(projectDir, 'mys-db', 'SELECT 1;')).code === 0,
+      'mys to accept connections',
+      180_000,
+    );
+  });
+
+  it('seed data is queryable', async () => {
+    const create = await mysql(
+      projectDir,
+      'mys-db',
+      'CREATE TABLE audit_check (id INT PRIMARY KEY); INSERT INTO audit_check VALUES (1), (2);',
+    );
+    expect(create.code).toBe(0);
+
+    const count = await mysql(projectDir, 'mys-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+  });
+
+  it('snapshot produces a SQL dump via mysqldump', async () => {
+    const result = await runCli(['snapshot', 'mys'], projectDir);
+    expect(result.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'mys');
+    expect(snapshot).toMatch(/\.sql$/);
+  });
+
+  it('restore recovers dropped data from the snapshot', async () => {
+    const drop = await mysql(projectDir, 'mys-db', 'DROP TABLE audit_check;');
+    expect(drop.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'mys');
+    const result = await runCli(['restore', snapshot, '-t', 'mys', '--force'], projectDir, 300_000);
+    expect(result.code).toBe(0);
+
+    await waitFor(
+      async () => (await mysql(projectDir, 'mys-db', 'SELECT 1;')).code === 0,
+      'mys to accept connections after restore',
+    );
+    const count = await mysql(projectDir, 'mys-db', 'SELECT count(*) FROM audit_check;');
+    expect(count.stdout.trim()).toBe('2');
+  });
+});

--- a/src/tests/integration/valkey.test.ts
+++ b/src/tests/integration/valkey.test.ts
@@ -1,0 +1,76 @@
+import {
+  composeExec,
+  createProject,
+  destroyProject,
+  latestSnapshot,
+  runCli,
+  waitFor,
+} from './helpers.js';
+
+// valkey-cli is the binary the image guarantees; redis-cli symlinks are not
+// relied upon anywhere.
+async function valkeyCli(projectDir: string, service: string, cmd: string[]) {
+  return composeExec(projectDir, service, ['valkey-cli', ...cmd]);
+}
+
+/**
+ * Valkey (the Linux Foundation Redis fork) earns its Tier 1 badge here: same
+ * BGSAVE/RDB-swap flow as Redis, but through valkey-cli and the valkey image.
+ */
+describe('valkey data lifecycle', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createProject('valkey');
+  });
+
+  afterAll(async () => {
+    await destroyProject(projectDir);
+  });
+
+  it('init and start bring up a healthy instance', async () => {
+    const initResult = await runCli(['init', '-n', 'vk', '-e', 'valkey', '-y'], projectDir);
+    expect(initResult.code).toBe(0);
+
+    const startResult = await runCli(['start', 'vk'], projectDir, 300_000);
+    expect(startResult.code).toBe(0);
+
+    await waitFor(
+      async () => (await valkeyCli(projectDir, 'vk-db', ['ping'])).stdout.includes('PONG'),
+      'vk to accept connections',
+    );
+  });
+
+  it('seed data is readable', async () => {
+    await valkeyCli(projectDir, 'vk-db', ['SET', 'audit:k1', 'v1']);
+    await valkeyCli(projectDir, 'vk-db', ['SET', 'audit:k2', 'v2']);
+
+    const get = await valkeyCli(projectDir, 'vk-db', ['GET', 'audit:k1']);
+    expect(get.stdout.trim()).toBe('v1');
+  });
+
+  it('snapshot captures an RDB file', async () => {
+    const result = await runCli(['snapshot', 'vk'], projectDir);
+    expect(result.code).toBe(0);
+
+    const snapshot = await latestSnapshot(projectDir, 'vk');
+    expect(snapshot).toMatch(/\.rdb$/);
+  });
+
+  it('restore recovers flushed keys from the RDB snapshot', async () => {
+    await valkeyCli(projectDir, 'vk-db', ['FLUSHALL']);
+    const empty = await valkeyCli(projectDir, 'vk-db', ['GET', 'audit:k1']);
+    expect(empty.stdout.trim()).toBe('');
+
+    const snapshot = await latestSnapshot(projectDir, 'vk');
+    const result = await runCli(['restore', snapshot, '-t', 'vk', '--force'], projectDir, 300_000);
+    expect(result.code).toBe(0);
+
+    await waitFor(
+      async () => (await valkeyCli(projectDir, 'vk-db', ['ping'])).stdout.includes('PONG'),
+      'vk to accept connections after restore',
+    );
+    const restored = await valkeyCli(projectDir, 'vk-db', ['GET', 'audit:k1']);
+    expect(restored.stdout.trim()).toBe('v1');
+  });
+});

--- a/src/tests/unit/templates.test.ts
+++ b/src/tests/unit/templates.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from '@jest/globals';
 import { DatabaseTemplates, getEngineTier } from '../../core/templates.js';
 
 describe('DatabaseTemplates - Basic Validation', () => {
-  it('should return all 22 configured databases', () => {
+  it('should return all 30 configured databases', () => {
     const templates = DatabaseTemplates.getAllTemplates();
-    expect(templates.size).toBe(22);
+    expect(templates.size).toBe(30);
   });
 
   it('should have valid structure for all templates', () => {
@@ -28,10 +28,11 @@ describe('DatabaseTemplates - Basic Validation', () => {
     expect(timeseriesEngines).toContain('timescaledb');
   });
 
-  it('should include all 3 key-value databases', () => {
+  it('should include all 4 key-value databases', () => {
     const keyValueEngines = DatabaseTemplates.getEnginesByType('keyvalue');
-    expect(keyValueEngines).toHaveLength(3);
+    expect(keyValueEngines).toHaveLength(4);
     expect(keyValueEngines).toContain('redis');
+    expect(keyValueEngines).toContain('valkey');
     expect(keyValueEngines).toContain('leveldb');
     expect(keyValueEngines).toContain('tikv');
   });
@@ -43,10 +44,27 @@ describe('DatabaseTemplates - Basic Validation', () => {
     expect(embeddedEngines).toContain('lmdb');
   });
 
-  it('should include 1 analytics database', () => {
+  it('should include all 2 analytics databases', () => {
     const analyticsEngines = DatabaseTemplates.getEnginesByType('analytics');
-    expect(analyticsEngines).toHaveLength(1);
+    expect(analyticsEngines).toHaveLength(2);
     expect(analyticsEngines).toContain('duckdb');
+    expect(analyticsEngines).toContain('clickhouse');
+  });
+
+  it('should include all 2 document databases', () => {
+    const documentEngines = DatabaseTemplates.getEnginesByType('document');
+    expect(documentEngines).toHaveLength(2);
+    expect(documentEngines).toContain('couchdb');
+    expect(documentEngines).toContain('mongodb');
+  });
+
+  it('flags mongodb (and only timescaledb besides it) as not fully open source', () => {
+    const info = DatabaseTemplates.getOpenSourceInfo();
+    const sourceAvailable = Object.entries(info)
+      .filter(([, engine]) => !engine.fullyOpenSource)
+      .map(([key]) => key)
+      .sort();
+    expect(sourceAvailable).toEqual(['mongodb', 'timescaledb']);
   });
 
   it('should include 1 wide column database', () => {
@@ -68,10 +86,12 @@ describe('DatabaseTemplates - Basic Validation', () => {
       'leveldb',
       'lmdb',
       'mariadb',
+      'mysql',
       'postgresql',
       'redis',
       'sqlite',
       'timescaledb',
+      'valkey',
     ]);
 
     // Unknown engines never get promoted by accident


### PR DESCRIPTION
## Context

Catalog expansion driven by real-world adoption: the eight most-requested absences, selected and licensed-checked against the project's open-source policy. The catalog grows **22 → 30 engines** across a new `document` category — without diluting the tier system's honesty: only engines whose data verbs are verified by CI enter Tier 1.

## What this PR adds

**Tier 1 on arrival** (wired into the verified data paths + own E2E suites):
- **MySQL 8.4** (GPLv2) — the most deployed database in the world. Reuses MariaDB's dump/replay flow, parametrized by client binary (`mysqldump`/`mysql`, which the `mysql:8` image ships — the mirror image of the `mariadb:11` divergence fixed in 0.8.x).
- **Valkey 8** (BSD-3) — the Linux Foundation Redis fork. Same BGSAVE → RDB-swap flow through `valkey-cli`; compat symlinks deliberately not relied on.

**Tier 2** (provision/start/stop/studio; data verbs best-effort per the matrix):
- **ClickHouse 24.8** (Apache-2.0) — fills the server-side analytics gap; `/play` UI in `hayai studio`.
- **Neo4j 5 Community** (GPLv3) — bolt (7687) is the published port; hayai publishes one port per instance, and a database apps can't reach is worse than one without its browser UI, so no dashboard is declared (documented in the template).
- **OpenSearch 2.19** (Apache-2.0) — single-node dev profile, security plugin off, bounded JVM heap.
- **CouchDB 3.4** (Apache-2.0) — Fauxton UI in `studio`.
- **Chroma** (Apache-2.0) — no healthcheck: the slim image ships neither curl nor wget; a check that can never pass reads as permanently unhealthy.
- **MongoDB 8** (SSPL) — the second documented **source-available exception** alongside TimescaleDB. `init` now prints a license notice for any `fullyOpenSource: false` engine at the moment of use, and the README names both exceptions instead of claiming an absolute that stopped being true.

**Plumbing that keeps the contracts intact:**
- Connection URIs for all eight; `env --format airflow` maps mysql/valkey (valid Airflow conn URI schemes); MongoDB stays in the skipped list rather than guessing at the `mongo` conn-type rewrite.
- Support sets (`RESTORABLE`/`FULLY_COMPATIBLE`/`MERGEABLE`), snapshot extensions and command help texts updated.
- New unit assertion pins the source-available exceptions to exactly `[mongodb, timescaledb]` — a licensing regression in the catalog now fails the build, same mechanism that guards the Tier 1 set.

## How it was verified

- Integration: **49/49 across 9 suites** against a live daemon, including the two new Tier 1 cycles (MySQL: mysqldump/replay; Valkey: BGSAVE/RDB-swap via valkey-cli). Unit: 13/13. Lint/format clean.
- Tier 2 engines are template-only additions: their compose generation flows through the same single-source engine-definition path validated by the existing suites.

## Risks and rollback

- CI integration job grows by the `mysql:8.4` (~600 MB) and `valkey:8-alpine` pulls — measured locally, the suite stays well under the job timeout.
- Tier 2 template values (images, envs, healthchecks) are best-effort by definition; the matrix says so. Any misconfigured Tier 2 engine affects only itself.
- MongoDB's SSPL inclusion is a **documented policy decision** (second exception), reversible by deleting one template + one matrix row; the license notice at `init` keeps it transparent to users.
- Revert is a clean `git revert` of the four commits.
