### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-05
+
+The trust release: every advertised data verb is now verified end-to-end
+against real containers in CI, the CLI gained an automation contract that
+orchestrators can script against, the engine catalog grew from 22 to 30 with
+an honest tier system, and the first Airflow integration landed.
+
 ### Added
 - End-to-end integration suite (`npm run test:integration`): the full
   init → start → seed → snapshot → destroy → restore cycle (plus clone and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hayai-db",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hayai-db",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayai-db",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "⚡ Instantly create and manage local databases with one command",
   "main": "dist/index.js",


### PR DESCRIPTION
## Context

All five feature PRs of the cycle (#29, #31, #32, #33, #34) are merged and green. This PR performs the mechanical release cut for **0.9.0** — the trust release.

## What this PR does

- Bumps `package.json`/`package-lock.json` to 0.9.0.
- Moves the consolidated Unreleased changelog under `## [0.9.0] - 2026-07-05` with a release summary paragraph, leaving a fresh empty Unreleased section.

## Release procedure after merge

Tag `v0.9.0` on the merged commit → `release.yml` runs its guard (tag must equal package.json version), builds and tests the exact tarball to be published, publishes to npm with OIDC provenance, and creates the GitHub Release from this version's changelog section.

## Verification

- Local build + unit tests green on the bumped tree; `dist/cli/index.js --version` reports 0.9.0.
- No functional changes in this PR.