### PR TITLE
ci(release): npm Trusted Publishing (OIDC) replaces NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,20 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # provenance attestation
+      id-token: write # OIDC trusted publishing + provenance attestation
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
+
+      # Publishing authenticates via npm Trusted Publishing (OIDC): the
+      # package's npm settings trust this repo+workflow, so no NPM_TOKEN
+      # secret exists to leak, expire, or trip 2FA (the failure mode that
+      # blocked the first v0.9.0 run with EOTP). Requires npm >= 11.5; the
+      # npm bundled with Node 22 is older, hence the explicit upgrade.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11
 
       - name: Download tarball
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -69,8 +77,6 @@ jobs:
 
       - name: Publish
         run: npm publish ./*.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Context

The v0.9.0 publish failed with `EOTP`: the npm account enforces 2FA on writes and the stored `NPM_TOKEN` is not an automation token. Instead of minting a 2FA-bypass token (a secret that can leak, expire and needs rotation), this switches the publish job to **npm Trusted Publishing (OIDC)** — the modern, tokenless path.

## What this PR does

- Removes the `NODE_AUTH_TOKEN`/`NPM_TOKEN` usage from the publish job; authentication now comes from the job's OIDC identity (`id-token: write` was already granted for provenance — same identity, one more use).
- Adds an explicit `npm install -g npm@11` step: trusted publishing requires npm ≥ 11.5 and Node 22 bundles an older npm.
- Provenance attestation is unchanged.

## One-time prerequisite (npm side, when access is restored)

npmjs.com → package `hayai-db` → **Settings → Trusted Publisher**: GitHub Actions, repository `hitoshyamamoto/hayai`, workflow `release.yml`, environment empty.

## Release retry procedure

The v0.9.0 tag points at a commit with the old workflow (runs re-execute their original definition), so after this merges **and** the npm-side publisher is configured: delete and re-push the `v0.9.0` tag from current master — the guard still passes (package.json is 0.9.0) and the pipeline republishes the same content.

## Risks and rollback

- Until the npm-side configuration exists, a release run fails at publish with an auth error — same blocked state as today, no regression.
- The `NPM_TOKEN` secret becomes unused and can be deleted from the repo settings afterwards.
- Revert: single-commit `git revert` restores token-based publishing.